### PR TITLE
Update workflows to use latest NodeJS.

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
This avoids warnings for action jobs that they use the deprecated NodeJS 20.
We have done similar changes in the VLCB-Arduino project. So sharing that experience here.