### PR TITLE
Issue/208 add test coverage

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -43,8 +43,16 @@ jobs:
       - name: Install dependencies
         run: npm install  # I wish package-lock.json was in git, cos then it would be "npm ci"
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run unit tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/lcov.info
+          if-no-files-found: warn
 
       - name: Upload diagnostic files
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ unit_tests/test_output
 ./unit_tests/test_output/
 VLCB-server/config/nodeDescriptors.json
 package-lock.json
-
+coverage

--- a/VLCB-server/cbusServer.js
+++ b/VLCB-server/cbusServer.js
@@ -20,6 +20,7 @@ class cbusServer {
     this.serialConnected = false
     this.targetSerial = null
     this.cbusServerPort = null
+    this.disposed = false
 
     //
     //
@@ -85,7 +86,9 @@ class cbusServer {
       this.serialConnected = false
       // restart timer so we start with the correct time gap
       clearInterval(this.reconnectTimer);
-      this.reconnectTimer = setInterval(this.serialConnectIntervalFunction.bind(this), 5000);
+      if (!this.disposed) {
+        this.reconnectTimer = setInterval(this.serialConnectIntervalFunction.bind(this), 5000);
+      }
       let eventData = {
         message: "Serial port closed",
         caption: data,
@@ -133,6 +136,11 @@ class cbusServer {
   // need to supply port number so unit tests can use a different port
   //
   async connect(CbusServerPort, targetSerial){
+
+    if (this.disposed) {
+      this.disposed = false
+      this.reconnectTimer = setInterval(this.serialConnectIntervalFunction.bind(this), 5000)
+    }
 
     // now start the listener...
     winston.info({message: name + `: connect: starting cbusServer listener on port ${CbusServerPort}`})
@@ -201,13 +209,21 @@ class cbusServer {
   // method to close the listener
   // Essential for unit testing, so that we can close the connection & open it again
   //
-  close(){
+  async close(){
     winston.info({message: name + ': close:'});
-    this.server.removeAllListeners()
-    this.server.close()
-    if (this.serialGC){
-      this.serialGC.close()
+    this.disposed = true
+    this.enableSerialReconnect = false
+    clearInterval(this.reconnectTimer)
+    for (const client of this.clients) {
+      client.destroy()
     }
+    this.clients = []
+    if (this.server.listening) {
+      await new Promise((resolve, reject) => {
+        this.server.close((error) => error ? reject(error) : resolve())
+      })
+    }
+    await serialGC.close()
   }
 
   //
@@ -248,4 +264,3 @@ class cbusServer {
 }
 
 module.exports = (config) => { return new cbusServer(config) }
-

--- a/VLCB-server/mergAdminNode.js
+++ b/VLCB-server/mergAdminNode.js
@@ -1621,7 +1621,9 @@ class cbusAdmin extends EventEmitter {
         let eventNI = this.nodeConfig.nodes[nodeNumber].storedEventsNI[eventIdentifier]
         winston.info({message: name + `: requestAllEventVariablesByIdentifier:  event ${JSON.stringify(eventNI)}`});
         try{
-          numberOfVariables = eventNI.variables[0]
+          if (eventNI.variables[0] != undefined) {
+            numberOfVariables = eventNI.variables[0]
+          }
         } catch (err){
           winston.error({message: name + `: requestAllEventVariablesByIdentifier: EV0 ${err}`});
         }

--- a/VLCB-server/mergAdminNode.js
+++ b/VLCB-server/mergAdminNode.js
@@ -38,7 +38,8 @@ class cbusAdmin extends EventEmitter {
     // keep a record of when any module descriptors are updated, so we know when to recheck
     this.moduleDescriptorFilesTimeStamp = Date.now()   // put valid milliseconds in to start
     this.nodeDescripter_Queue = []      // create a queue for reading MDF's for nodes
-    setInterval(this.checkNodeDescriptorIntervalFunc.bind(this), 20);
+    this.intervalHandles = []
+    this.intervalHandles.push(setInterval(this.checkNodeDescriptorIntervalFunc.bind(this), 20));
 
     const outHeader = ((((this.pr1 * 4) + this.pr2) * 128) + this.canId) << 5
     this.header = ':S' + outHeader.toString(16).toUpperCase() + 'N'
@@ -46,16 +47,16 @@ class cbusAdmin extends EventEmitter {
     this.lastCbusTrafficTime = Date.now()   // put valid milliseconds in to start
     this.LastCbusMessage = null
     this.CBUS_Queue = []
-    setInterval(this.sendCBUSIntervalFunc.bind(this), 10);
+    this.intervalHandles.push(setInterval(this.sendCBUSIntervalFunc.bind(this), 10));
     this.awaitingNodeReset_Queue = []
-    setInterval(this.awaitingNodeResetIntervalFunc.bind(this), 500);
+    this.intervalHandles.push(setInterval(this.awaitingNodeResetIntervalFunc.bind(this), 500));
     this.eventsChanged = false
     // update client if anything changed
-    setInterval(this.updateClients.bind(this), 200);
+    this.intervalHandles.push(setInterval(this.updateClients.bind(this), 200));
     this.opcodeTracker = {}
     this.connectionDetails = null
 
-    this.config.eventBus.on('GRID_CONNECT_RECEIVE', async function (data) {
+    this.gridConnectReceiveHandler = async function (data) {
       //winston.debug({message: name + `: GRID_CONNECT_RECEIVE ${data}`})
       try{
         this.lastCbusTrafficTime = Date.now()     // store this time stamp
@@ -69,7 +70,8 @@ class cbusAdmin extends EventEmitter {
       } catch (err) {
         winston.error({message: name + `: GRID_CONNECT_RECEIVE: ${err}`})
       }
-    }.bind(this))
+    }.bind(this)
+    this.config.eventBus.on('GRID_CONNECT_RECEIVE', this.gridConnectReceiveHandler)
 
     //
     this.actions = { //actions when Opcodes are received
@@ -1952,6 +1954,14 @@ class cbusAdmin extends EventEmitter {
     } catch (err){
       winston.error({message: name + `: getNodeDescriptor: node ${nodeNumber} ${err}` });              
     }
+  }
+
+  dispose(){
+    for (const intervalHandle of this.intervalHandles) {
+      clearInterval(intervalHandle)
+    }
+    this.intervalHandles = []
+    this.config.eventBus.removeListener('GRID_CONNECT_RECEIVE', this.gridConnectReceiveHandler)
   }
 
 };

--- a/VLCB-server/mergAdminNode.js
+++ b/VLCB-server/mergAdminNode.js
@@ -55,21 +55,11 @@ class cbusAdmin extends EventEmitter {
     this.intervalHandles.push(setInterval(this.updateClients.bind(this), 200));
     this.opcodeTracker = {}
     this.connectionDetails = null
+    this.gridConnectReceiveQueue = Promise.resolve()
 
-    this.gridConnectReceiveHandler = async function (data) {
-      //winston.debug({message: name + `: GRID_CONNECT_RECEIVE ${data}`})
-      try{
-        this.lastCbusTrafficTime = Date.now()     // store this time stamp
-        let cbusMsg = cbusLibrary.decode(data)
-        winston.debug({message: name + `: GRID_CONNECT_RECEIVE ${JSON.stringify(cbusMsg)}`})
-        //
-        this.emit('nodeTraffic', {direction: 'In', json: cbusMsg});
-        if (this.isMessageValid(cbusMsg)){
-          await this.action_message(cbusMsg)
-        }
-      } catch (err) {
-        winston.error({message: name + `: GRID_CONNECT_RECEIVE: ${err}`})
-      }
+    this.gridConnectReceiveHandler = function (data) {
+      this.gridConnectReceiveQueue = this.gridConnectReceiveQueue.then(() => this.processGridConnectMessage(data))
+      return this.gridConnectReceiveQueue
     }.bind(this)
     this.config.eventBus.on('GRID_CONNECT_RECEIVE', this.gridConnectReceiveHandler)
 
@@ -503,6 +493,24 @@ class cbusAdmin extends EventEmitter {
         // GRSP was for an event command
         winston.info({message: `mergAdminNode: GRSP for event command : node ` + nodeNumber});
       }
+    }
+  }
+
+  //
+  //
+  async processGridConnectMessage(data) {
+    //winston.debug({message: name + `: GRID_CONNECT_RECEIVE ${data}`})
+    try{
+      this.lastCbusTrafficTime = Date.now()     // store this time stamp
+      let cbusMsg = cbusLibrary.decode(data)
+      winston.debug({message: name + `: GRID_CONNECT_RECEIVE ${JSON.stringify(cbusMsg)}`})
+      //
+      this.emit('nodeTraffic', {direction: 'In', json: cbusMsg});
+      if (this.isMessageValid(cbusMsg)){
+        await this.action_message(cbusMsg)
+      }
+    } catch (err) {
+      winston.error({message: name + `: GRID_CONNECT_RECEIVE: ${err}`})
     }
   }
 

--- a/VLCB-server/mergAdminNode.js
+++ b/VLCB-server/mergAdminNode.js
@@ -65,7 +65,7 @@ class cbusAdmin extends EventEmitter {
         //
         this.emit('nodeTraffic', {direction: 'In', json: cbusMsg});
         if (this.isMessageValid(cbusMsg)){
-          this.action_message(cbusMsg)
+          await this.action_message(cbusMsg)
         }
       } catch (err) {
         winston.error({message: name + `: GRID_CONNECT_RECEIVE: ${err}`})

--- a/VLCB-server/messageRouter.js
+++ b/VLCB-server/messageRouter.js
@@ -20,7 +20,7 @@ class messageRouter{
     this.cbusClient = new net.Socket()
     this.config = configuration
     this.eventBus = configuration.eventBus
-    setInterval(this.connectIntervalFunction.bind(this), 5000);
+    this.connectInterval = setInterval(this.connectIntervalFunction.bind(this), 5000);
     this.enableReconnect = false
     this.connected = false
     this.cbusClientHost = null
@@ -78,12 +78,13 @@ class messageRouter{
       this.connected = false
     }.bind(this))
 
-    this.config.eventBus.on('GRID_CONNECT_SEND', function (data) {
+    this.gridConnectSendHandler = function (data) {
       let cbusLibMsg = cbusLib.decode(data)
       winston.info({message: name + ': GRID_CONNECT_SEND ' + cbusLibMsg.text});
       winston.debug({message: name + `:  GRID_CONNECT_SEND ${data}`})
       this.sendCbusMessage(data)
-    }.bind(this))
+    }.bind(this)
+    this.config.eventBus.on('GRID_CONNECT_SEND', this.gridConnectSendHandler)
 
   }
 
@@ -153,7 +154,22 @@ class messageRouter{
     this.cbusClient.write(cbusMSG)
   }
 
+  async close(){
+    this.enableReconnect = false
+    this.connected = false
+    clearInterval(this.connectInterval)
+    this.config.eventBus.removeListener('GRID_CONNECT_SEND', this.gridConnectSendHandler)
+
+    if (this.cbusClient.destroyed) {
+      return
+    }
+
+    await new Promise((resolve) => {
+      this.cbusClient.once('close', resolve)
+      this.cbusClient.destroy()
+    })
+  }
+
 }
 
 module.exports = (configuration) => { return new messageRouter(configuration) }
-

--- a/VLCB-server/messageRouter.js
+++ b/VLCB-server/messageRouter.js
@@ -25,6 +25,7 @@ class messageRouter{
     this.connected = false
     this.cbusClientHost = null
     this.cbusClientPort = null
+    this.connectPromise = null
 
     //
     // Setup the handlers for cbusClient events
@@ -95,9 +96,25 @@ class messageRouter{
     this.cbusClientHost = remoteAddress
     this.cbusClientPort = cbusPort
     winston.info({message:name + ': try Connect ' + remoteAddress + ' on ' + cbusPort})
+
+    if (this.connected) {
+      return Promise.resolve()
+    }
+
+    if (this.connectPromise) {
+      return this.connectPromise
+    }
+
     // connect to remote socket for CBUS messages
-    try{
-      this.cbusClient.connect(cbusPort, remoteAddress, function () {
+    this.connectPromise = new Promise((resolve, reject) => {
+      const cleanup = () => {
+        this.cbusClient.removeListener('connect', onConnect)
+        this.cbusClient.removeListener('error', onError)
+        this.cbusClient.removeListener('close', onClose)
+      }
+
+      const onConnect = () => {
+        cleanup()
         let message = 'Connected to ' + remoteAddress + ' on ' + cbusPort
         winston.info({message:name + ': ' + message})
         this.connected = true
@@ -109,7 +126,30 @@ class messageRouter{
         }
         this.config.eventBus.emit ('SERVER_NOTIFICATION', data)
         this.enableReconnect = true
-      }.bind(this));
+        resolve()
+      }
+
+      const onError = (error) => {
+        cleanup()
+        reject(error)
+      }
+
+      const onClose = () => {
+        cleanup()
+        reject(new Error('Connection closed before it was established'))
+      }
+
+      this.cbusClient.once('connect', onConnect)
+      this.cbusClient.once('error', onError)
+      this.cbusClient.once('close', onClose)
+
+      try {
+        this.cbusClient.connect(cbusPort, remoteAddress)
+      } catch (error) {
+        cleanup()
+        reject(error)
+      }
+
       if (this.cbusClient){
         winston.info({message:name + ': cbusClient connection succeeded: '})
         winston.info({message:name + ': cbusClient socket: ' +JSON.stringify(this.cbusClient)})
@@ -117,15 +157,16 @@ class messageRouter{
       } else {
         winston.info({message:name + ': cbusClient connection failed: '})
       }
-    } catch(e){
-      winston.info({message:name + ': cbusClient connection failed: ' + e})
-    }    
+    }).finally(() => {
+      this.connectPromise = null
+    })
+
+    return this.connectPromise
   }
 
   connectIntervalFunction(){
     winston.debug({message:name + ': cbusClient check connection:'})
     if (this.cbusClient.readyState == 'opening'){
-      this.connected = true
       let data = {
         message: "Network port opening",
         type: "info",
@@ -139,7 +180,9 @@ class messageRouter{
         winston.debug({message:name + ': cbusClient still connected:'})
       } else {
         winston.info({message:name + ': cbusClient not connected:'})
-        this.connect(this.cbusClientHost, this.cbusClientPort)
+        this.connect(this.cbusClientHost, this.cbusClientPort).catch(function (error) {
+          winston.debug({message:name + ': cbusClient reconnect failed: ' + error.message})
+        })
       }
     }
   }

--- a/VLCB-server/serialGC.js
+++ b/VLCB-server/serialGC.js
@@ -95,8 +95,20 @@ class serialGC  extends EventEmitter {
     return true
   }  // end connect
 
-  close(){
-    this.serialPort.close()
+  async close(){
+    if (!this.serialPort) {
+      return
+    }
+
+    const serialPort = this.serialPort
+    this.serialPort = undefined
+    if (!serialPort.isOpen) {
+      return
+    }
+
+    await new Promise((resolve, reject) => {
+      serialPort.close((error) => error ? reject(error) : resolve())
+    })
   }
     
   write(data){
@@ -258,7 +270,6 @@ module.exports = new serialGC()
     
 
   
-
 
 
 

--- a/VLCB-server/socketServer.js
+++ b/VLCB-server/socketServer.js
@@ -967,7 +967,15 @@ exports.socketServer = function(config, node, messageRouter, cbusServer, program
   
   //
   //
-  server.listen(config.getSocketServerPort(), () => console.log(`SS: Server running on port ${config.getSocketServerPort()}`))
+  const listening = new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(config.getSocketServerPort(), () => {
+      server.removeListener('error', reject)
+      const address = server.address()
+      console.log(`SS: Server running on port ${address.port}`)
+      resolve(address)
+    })
+  })
 
   //*************************************************************************************** */
   //
@@ -1116,8 +1124,11 @@ exports.socketServer = function(config, node, messageRouter, cbusServer, program
     io.emit('PROGRAM_NODE_PROGRESS', downloadData.text)
   });	        
 
+  return {
+    listening,
+    close: () => new Promise((resolve) => io.close(resolve))
+  }
 }
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,22 @@
   "scripts": {
     "lint": "eslint",
     "start": "node ./main.js",
-    "test": "./node_modules/.bin/mocha ./unit_tests/*.spec.js --timeout 150000"
+    "test": "./node_modules/.bin/mocha ./unit_tests/*.spec.js --timeout 150000",
+    "test:coverage": "c8 npm test"
+  },
+  "c8": {
+    "all": true,
+    "include": [
+      "main.js",
+      "VLCB-server/**/*.js"
+    ],
+    "exclude": [
+      "unit_tests/**"
+    ],
+    "reporter": [
+      "text",
+      "lcov"
+    ]
   },
   "dependencies": {
     "adm-zip": "^0.5.16",
@@ -26,6 +41,7 @@
     "winston": "^3.11.0"
   },
   "devDependencies": {
+    "c8": "^12.0.0",
     "chai": "^4.2.0",
     "eslint": "^10.8.1",
     "globals": "^17.11.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint",
     "start": "node ./main.js",
-    "test": "./node_modules/.bin/mocha ./unit_tests/*.spec.js --timeout 150000 --exit"
+    "test": "./node_modules/.bin/mocha ./unit_tests/*.spec.js --timeout 150000"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/unit_tests/cbusServer.spec.js
+++ b/unit_tests/cbusServer.spec.js
@@ -70,18 +70,15 @@ describe('cbusServer tests', function(){
   // it doesn't mean the serial port has connected
   // see serialGC.spec.js for serial port tests
   //
-  itParam("connect test ${JSON.stringify(value)}", GetTestCase_connect(), async function (done, value) {
+  itParam("connect test ${JSON.stringify(value)}", GetTestCase_connect(), async function (value) {
 
     winston.info({message: name + ': BEGIN connect test: ' + JSON.stringify(value)});
     var result = await cbusServer.connect(9999, value.targetSerial)
 
-    setTimeout(function(){
-      winston.info({message: name +': connect test: result ' + result});
-      cbusServer.close()
-      expect(result).to.equal(value.result);
-      winston.info({message: name +': END connect test'});
-			done();
-		}, 20);
+    winston.info({message: name +': connect test: result ' + result});
+    await cbusServer.close()
+    expect(result).to.equal(value.result);
+    winston.info({message: name +': END connect test'});
   })
 
 })

--- a/unit_tests/configuration.spec.js
+++ b/unit_tests/configuration.spec.js
@@ -34,7 +34,7 @@ const config = require('../VLCB-server/configuration.js')(testSystemDirectory, l
 config.singleUserDirectory = testUserConfigPath
 config.currentUserDirectory = config.singleUserDirectory
 
-async function createTestFiles(){
+function createTestFiles(){
   var testContent = {"timestamp":Date.now()}
 
   // ensure the following files exist
@@ -72,7 +72,7 @@ async function createTestFiles(){
 describe('configuration tests', function(){
 
 
-	before(function(done) {
+	before(function() {
 		winston.info({message: ' '});
 		winston.info({message: '================================================================================'});
     //                      12345678901234567890123456789012345678900987654321098765432109876543210987654321
@@ -81,8 +81,6 @@ describe('configuration tests', function(){
 		winston.info({message: ' '});
     //
     createTestFiles()
-    //
-		done();
 	});
 
 	beforeEach(function() {
@@ -91,12 +89,8 @@ describe('configuration tests', function(){
         // ensure expected CAN header is reset before each test run
 	});
 
-	after(function(done) {
+	after(function() {
  		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
 	});																										
 
 
@@ -109,7 +103,7 @@ describe('configuration tests', function(){
   //
   // Combined node backup test - does read, write, list & delete
   //
-  it("Node BackupFile test", function (done) {
+  it("Node BackupFile test", function () {
     winston.info({message: 'unit_test: BEGIN BackupFile test '})
     let layoutName = 'test_backup_layout'
     let nodeNumber = 999
@@ -131,25 +125,20 @@ describe('configuration tests', function(){
     //
     config.writeNodeBackupFile(layoutName, nodeNumber, fileName1, backupFile1)
     var result = config.readNodeBackup(layoutName, nodeNumber, fileName1)
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect(JSON.stringify(result.layoutName)).to.equal(JSON.stringify(layoutName));
-      // 3rd backup so should be three entries, but just check for first backup
-      config.writeNodeBackupFile(layoutName, nodeNumber, fileName3, backupFile3)
-      var list1 = config.getListOfNodeBackups(layoutName, nodeNumber)
-      expect (list1).to.include(fileName1)
-      expect(list1.length).to.equal(2 + startingCount)
-      // now delete initial backup & get new list
-      config.deleteNodeBackup(layoutName, nodeNumber, fileName1)
-      var list2 = config.getListOfNodeBackups(layoutName, nodeNumber)
-      expect (list2).to.not.include(fileName1)
-      expect(list2.length).to.equal(1 + startingCount)
-      var list3 = config.renameNodeBackup(layoutName, nodeNumber, fileName3, "testBackupFile.json")
-      winston.info({message: 'list3: ' + JSON.stringify(list3)})
-      expect (list3).to.include("testBackupFile.json")
-      winston.info({message: 'unit_test: END BackupFile test'})
-      done();
-		}, 10);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect(JSON.stringify(result.layoutName)).to.equal(JSON.stringify(layoutName));
+    config.writeNodeBackupFile(layoutName, nodeNumber, fileName3, backupFile3)
+    var list1 = config.getListOfNodeBackups(layoutName, nodeNumber)
+    expect (list1).to.include(fileName1)
+    expect(list1.length).to.equal(2 + startingCount)
+    config.deleteNodeBackup(layoutName, nodeNumber, fileName1)
+    var list2 = config.getListOfNodeBackups(layoutName, nodeNumber)
+    expect (list2).to.not.include(fileName1)
+    expect(list2.length).to.equal(1 + startingCount)
+    var list3 = config.renameNodeBackup(layoutName, nodeNumber, fileName3, "testBackupFile.json")
+    winston.info({message: 'list3: ' + JSON.stringify(list3)})
+    expect (list3).to.include("testBackupFile.json")
+    winston.info({message: 'unit_test: END BackupFile test'})
   })
 
   
@@ -157,7 +146,7 @@ describe('configuration tests', function(){
   // returns list of backup file names for all nodes
   // also creates eventBus 'LIST_OF_BACKUPS_FOR_ALL_NODES' with list as data
   //
-  it("getListOfBackupsForAllNodes test", function (done) {
+  it("getListOfBackupsForAllNodes test", function () {
     winston.info({message: 'unit_test: BEGIN getListOfBackupsForAllNodes test '})
     var layoutName = 'test_backup_layout'
     var backupNode1 = {moduleName:"CANACC5"}
@@ -171,47 +160,41 @@ describe('configuration tests', function(){
       eventList = data
       winston.info({message: `unit_test: eventBus LIST_OF_BACKUPS_FOR_ALL_NODES: ${JSON.stringify(eventList)}`})
     })
-    setTimeout(function(){
-      var list = config.getListOfBackupsForAllNodes(layoutName)
-      winston.info({message: `unit_test: getListOfBackupsForAllNodes list: ${JSON.stringify(list)}`})
-      expect (list["Node300"].length).to.equal(2)
-      expect (list["Node301"].length).to.equal(1)
-      expect (list).to.equal(eventList)
-      winston.info({message: 'unit_test: END getListOfBackupsForAllNodes test '})
-      done();
-		}, 100);
+    var list = config.getListOfBackupsForAllNodes(layoutName)
+    winston.info({message: `unit_test: getListOfBackupsForAllNodes list: ${JSON.stringify(list)}`})
+    expect (list["Node300"].length).to.equal(2)
+    expect (list["Node301"].length).to.equal(1)
+    expect (list).to.equal(eventList)
+    winston.info({message: 'unit_test: END getListOfBackupsForAllNodes test '})
   })
 
 
   //
   // test writeBusTraffic
   //
-  it("writeBusTraffic test", function (done) {
+  it("writeBusTraffic test", async function () {
     winston.info({message: 'unit_test: BEGIN writeBusTraffic test '})
     config.writeBusTraffic("test data 1")
     config.writeBusTraffic("test data 2")
     config.writeBusTraffic("test data 3")
-    setTimeout(function(){
-      done();
-      winston.info({message: 'unit_test: END writeBusTraffic test '})
-		}, 50);
+    await new Promise((resolve, reject) => {
+      config.bustrafficLogStream.write('', (error) => error ? reject(error) : resolve())
+    })
+    winston.info({message: 'unit_test: END writeBusTraffic test '})
   })
 
 
   //
   // test createDirectory
   //
-  it("createDirectory test", function (done) {
+  it("createDirectory test", function () {
     winston.info({message: 'unit_test: BEGIN createDirectory test '})
     var layout = 'test_createDirectory_' + Date.now()
     config.createDirectory(path.join(testUserConfigPath, 'layouts', layout) )
     config.currentUserDirectory = testUserConfigPath
     var layout_list = config.getListOfLayouts()
-    setTimeout(function(){
-      winston.info({message: 'unit test: layout_list: ' + JSON.stringify(layout_list)})
-      expect(layout_list).to.include(layout)
-      done();
-		}, 50);
+    winston.info({message: 'unit test: layout_list: ' + JSON.stringify(layout_list)})
+    expect(layout_list).to.include(layout)
   })
 
   //
@@ -227,44 +210,35 @@ describe('configuration tests', function(){
 
 
   //
-  it("eventBus test", function (done) {
+  it("eventBus test", function () {
     winston.info({message: 'unit_test: BEGIN eventBus test '});
     var result = false
     config.eventBus.once('test', function () {
       result = true
     })
     config.eventBus.emit('test')
-    setTimeout(function(){
-      winston.info({message: 'result: ' + result})
-      expect(result).to.equal(true);
-      winston.info({message: 'unit_test: END test test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + result})
+    expect(result).to.equal(true);
+    winston.info({message: 'unit_test: END test test'})
   })
 
   //
   //
-  it("copyLayout", function (done) {
+  it("copyLayout", function () {
     winston.info({message: 'unit_test: BEGIN copyLayout test '})
     config.copyLayout("default layout", "copied Layout")
-    setTimeout(function(){
-      winston.info({message: 'unit_test: END copyLayout test'})
-      done();
-		}, 50);
+    winston.info({message: 'unit_test: END copyLayout test'})
   })
 
 
   //
   //
-  it("readLayoutData", function (done) {
+  it("readLayoutData", function () {
     winston.info({message: 'unit_test: BEGIN readLayoutData test '})
     const result = config.readLayoutData()
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect(result).to.have.property('layoutDetails')
-      winston.info({message: 'unit_test: END readLayoutData test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect(result).to.have.property('layoutDetails')
+    winston.info({message: 'unit_test: END readLayoutData test'})
   })
 
   function GetTestCase_layout() {
@@ -279,7 +253,7 @@ describe('configuration tests', function(){
   }
 
   //
-  itParam("writeLayoutData test ${JSON.stringify(value)}", GetTestCase_layout(), function (done, value) {
+  itParam("writeLayoutData test ${JSON.stringify(value)}", GetTestCase_layout(), function (value) {
     winston.info({message: 'unit_test: BEGIN writeLayoutData test '})
     var data = {
       "layoutDetails": {
@@ -293,12 +267,9 @@ describe('configuration tests', function(){
     config.setCurrentLayoutFolder("write_test")
     config.writeLayoutData(data)
     const result = config.readLayoutData()
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect(result.layoutDetails.title).to.equal(value.layout + " layout");
-      winston.info({message: 'unit_test: END writeLayoutData test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect(result.layoutDetails.title).to.equal(value.layout + " layout");
+    winston.info({message: 'unit_test: END writeLayoutData test'})
   })
 
 
@@ -314,7 +285,7 @@ describe('configuration tests', function(){
   }
 
   //
-  itParam("writeNodeConfig test ${JSON.stringify(value)}", GetTestCase_node(), function (done, value) {
+  itParam("writeNodeConfig test ${JSON.stringify(value)}", GetTestCase_node(), function (value) {
     winston.info({message: 'unit_test: BEGIN writeNodeConfig test '})
     var data = {
       "nodes": {
@@ -325,37 +296,28 @@ describe('configuration tests', function(){
     }
     config.writeNodeConfig(data)
     const result = config.readNodeConfig()
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect(result.nodes["301"].nodeNumber).to.equal(value.nodeNumber);
-      winston.info({message: 'unit_test: END writeNodeConfig test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect(result.nodes["301"].nodeNumber).to.equal(value.nodeNumber);
+    winston.info({message: 'unit_test: END writeNodeConfig test'})
   })
 
   //
-  it("readMergConfig test", function (done) {
+  it("readMergConfig test", function () {
     winston.info({message: 'unit_test: BEGIN readMergConfig test '})
     var result = config.readMergConfig()
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect(result).to.have.property('modules')
-      winston.info({message: 'unit_test: END readMergConfig test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect(result).to.have.property('modules')
+    winston.info({message: 'unit_test: END readMergConfig test'})
   })
 
 
   //
-  it("readServiceDefinitions test", function (done) {
+  it("readServiceDefinitions test", function () {
     winston.info({message: 'unit_test: BEGIN readServiceDefinitions test '})
     var result = config.readServiceDefinitions()
-    setTimeout(function(){
-      winston.info({message: 'result length: ' + JSON.stringify(result).length})
-      expect(JSON.stringify(result).length).to.be.greaterThan(3)
-      winston.info({message: 'unit_test: END readServiceDefinitions test'})
-        done();
-		}, 50);
+    winston.info({message: 'result length: ' + JSON.stringify(result).length})
+    expect(JSON.stringify(result).length).to.be.greaterThan(3)
+    winston.info({message: 'unit_test: END readServiceDefinitions test'})
   })
 
 
@@ -365,7 +327,7 @@ describe('configuration tests', function(){
   // write module - should be written to test 'user' module folder
   // read file & check it contains the written data
   //
-  it("writeModuleDescriptor test", function (done) {
+  it("writeModuleDescriptor test", function () {
     winston.info({message: 'unit_test: BEGIN writeModuleDescriptor test '})
     // ensure 'user' modules directory exists
     config.currentUserDirectory = testUserConfigPath
@@ -385,32 +347,26 @@ describe('configuration tests', function(){
                         "moduleDescriptorFilename":"writeTest.json"}
       config.writeModuleDescriptor(testPattern)
     }
-    setTimeout(function(){
-      const file = jsonfile.readFileSync(testFilePath)
-      winston.info({message: 'unit_test: result length: ' + JSON.stringify(file).length})
-      expect(JSON.stringify(file).length).to.be.greaterThan(3)
-      expect (file.toString()).to.be.equal(testPattern.toString())
-      expect (JSON.stringify(file)).to.be.equal(JSON.stringify(testPattern))
-      winston.info({message: 'unit_test: file: ' + JSON.stringify(file)})
-      winston.info({message: 'unit_test: END writeModuleDescriptor test'})
-      done();
-		}, 50);
+    const file = jsonfile.readFileSync(testFilePath)
+    winston.info({message: 'unit_test: result length: ' + JSON.stringify(file).length})
+    expect(JSON.stringify(file).length).to.be.greaterThan(3)
+    expect (file.toString()).to.be.equal(testPattern.toString())
+    expect (JSON.stringify(file)).to.be.equal(JSON.stringify(testPattern))
+    winston.info({message: 'unit_test: file: ' + JSON.stringify(file)})
+    winston.info({message: 'unit_test: END writeModuleDescriptor test'})
   })
 
   //
   //
   //
-  it("getModuleDescriptorFileList test", function (done) {
+  it("getModuleDescriptorFileList test", function () {
     winston.info({message: 'unit_test: BEGIN getModuleDescriptorFileList test '})
     //
     winston.info({message: 'currentUserDirectory: ' + config.currentUserDirectory})
     var result = config.getModuleDescriptorFileList("YYYY")
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(result)})
-      expect (result.length).to.be.equal(3)
-      winston.info({message: 'unit_test: END getModuleDescriptorFileList test'})
-        done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(result)})
+    expect (result.length).to.be.equal(3)
+    winston.info({message: 'unit_test: END getModuleDescriptorFileList test'})
   })
 
 
@@ -526,69 +482,54 @@ describe('configuration tests', function(){
 
   //
   //
-  it("archiveLogs test ", function (done) {
+  it("archiveLogs test ", async function () {
     winston.info({message: 'unit_test: BEGIN archiveLogs test '});
-    config.archiveLogs()
-    setTimeout(function(){
-      winston.info({message: 'unit_test: END archiveLogs test'});
-      done();
-		}, 50);
+    await config.archiveLogs()
+    winston.info({message: 'unit_test: END archiveLogs test'});
   })
 
   //
   //
-  it("limitNumberOfArchivedLogs test ", function (done) {
+  it("limitNumberOfArchivedLogs test ", function () {
     winston.info({message: 'unit_test: BEGIN limitNumberOfArchivedLogs test '});
     config.limitNumberOfArchivedLogs()
-    setTimeout(function(){
-      winston.info({message: 'unit_test: END limitNumberOfArchivedLogs test'});
-      done();
-		}, 50);
+    winston.info({message: 'unit_test: END limitNumberOfArchivedLogs test'});
   })
 
   //
   //
-  it("getArchivedLogsList test", function (done) {
+  it("getArchivedLogsList test", function () {
     winston.info({message: 'unit_test: BEGIN getArchivedLogsList test '})
     var list = config.getArchivedLogsList()
-    setTimeout(function(){
-      winston.info({message: 'result: ' + JSON.stringify(list)})
-      winston.info({message: 'count: ' + list.length})
-      expect(list.length).to.be.above(0)
-      winston.info({message: 'unit_test: END getArchivedLogsList test'})
-      done();
-		}, 50);
+    winston.info({message: 'result: ' + JSON.stringify(list)})
+    winston.info({message: 'count: ' + list.length})
+    expect(list.length).to.be.above(0)
+    winston.info({message: 'unit_test: END getArchivedLogsList test'})
   })
 
 
 
   //
   //
-  it("readBinaryFile test", function (done) {
+  it("readBinaryFile test", function () {
     winston.info({message: 'unit_test: BEGIN readBinaryFile test '})
     let directory = path.join(config.appStorageDirectory, "archives", "logs")
     winston.info({message: 'directory: ' + directory})
     var list = config.getArchivedLogsList()
     winston.info({message: 'log: ' + list[0]})
     var data = config.readBinaryFile(directory,list[0])
-    setTimeout(function(){
-      winston.info({message: 'unit_test: RESULT: data length: ' + data.length})
-      expect(data.length).to.be.above(0)
-      winston.info({message: 'unit_test: END readBinaryFile test'})
-      done();
-		}, 50);
+    winston.info({message: 'unit_test: RESULT: data length: ' + data.length})
+    expect(data.length).to.be.above(0)
+    winston.info({message: 'unit_test: END readBinaryFile test'})
   })
 
   //
   // test writeLogFile
   //
-  it("writeLogFile test", function (done) {
+  it("writeLogFile test", function () {
     winston.info({message: 'unit_test: BEGIN writeLogFile test '})
     config.writeLogFile("testfile", {"test data 1":1})
-    setTimeout(function(){
-      done();
-      winston.info({message: 'unit_test: END writeLogFile test '})
-		}, 50);
+    winston.info({message: 'unit_test: END writeLogFile test '})
   })
 
 

--- a/unit_tests/longMessage.spec.js
+++ b/unit_tests/longMessage.spec.js
@@ -18,7 +18,7 @@ const logPrefix = "UNIT_TEST"
 describe('long message tests', function(){
 
 
-	before(function(done) {
+	before(function() {
 		winston.info({message: ' '});
 		winston.info({message: '================================================================================'});
     //                      12345678901234567890123456789012345678900987654321098765432109876543210987654321
@@ -27,7 +27,6 @@ describe('long message tests', function(){
 		winston.info({message: ' '});
     //
     longMessage.setup(config)
-		done();
 	});
 
 	beforeEach(function() {
@@ -36,12 +35,8 @@ describe('long message tests', function(){
         // ensure expected CAN header is reset before each test run
 	});
 
-	after(function(done) {
+	after(function() {
  		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
 	});																										
 
 
@@ -53,7 +48,7 @@ describe('long message tests', function(){
 
   // LM_REQUEST (220)
   //
-  it("LM_REQUEST test", function (done) {
+  it("LM_REQUEST test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_REQUEST test:'});
     longMessage.channels = []   // clear channels
     let channel = 99
@@ -62,17 +57,14 @@ describe('long message tests', function(){
     let testMessage = cbusLib.decode(cbusLib.encodeLM_REQUEST(channel, use, option_flags))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      expect(longMessage.channels[channel]).to.not.be.undefined
-      winston.info({message: logPrefix +': END LM_REQUEST test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    expect(longMessage.channels[channel]).to.not.be.undefined
+    winston.info({message: logPrefix +': END LM_REQUEST test'});
   })
 
   // START_MESSAGE (239)
   //
-  it("LM_START_MESSAGE test", function (done) {
+  it("LM_START_MESSAGE test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_START_MESSAGE test:'});
     longMessage.channels = []   // clear channels
     let channel = 99
@@ -82,69 +74,57 @@ describe('long message tests', function(){
     let testMessage = cbusLib.decode(cbusLib.encodeLM_START_MESSAGE(channel, use, nodeNumber, option_flags))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      expect(longMessage.channels[channel]).to.not.be.undefined
-      let currentMessage = longMessage.channels[channel].currentMessage
-      expect(longMessage.channels[channel][currentMessage].use).to.equal(use)
-      expect(longMessage.channels[channel][currentMessage].option_flags).to.equal(option_flags)
-      winston.info({message: logPrefix +': END LM_START_MESSAGE test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    expect(longMessage.channels[channel]).to.not.be.undefined
+    let currentMessage = longMessage.channels[channel].currentMessage
+    expect(longMessage.channels[channel][currentMessage].use).to.equal(use)
+    expect(longMessage.channels[channel][currentMessage].option_flags).to.equal(option_flags)
+    winston.info({message: logPrefix +': END LM_START_MESSAGE test'});
   })
 
   //
   //
-  it("LM_PROPOSE_CHANNEL test", function (done) {
+  it("LM_PROPOSE_CHANNEL test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_PROPOSE_CHANNEL test:'});
     longMessage.channels = []   // clear channels
     let channel = 99
     let testMessage = cbusLib.decode(cbusLib.encodeLM_PROPOSE_CHANNEL(channel))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      winston.info({message: logPrefix +': END LM_PROPOSE_CHANNEL test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    winston.info({message: logPrefix +': END LM_PROPOSE_CHANNEL test'});
   })
 
   //
   //
-  it("LM_CLAIM_CHANNEL test", function (done) {
+  it("LM_CLAIM_CHANNEL test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_CLAIM_CHANNEL test:'});
     longMessage.channels = []   // clear channels
     let channel = 99
     let testMessage = cbusLib.decode(cbusLib.encodeLM_CLAIM_CHANNEL(channel))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      winston.info({message: logPrefix +': END LM_CLAIM_CHANNEL test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    winston.info({message: logPrefix +': END LM_CLAIM_CHANNEL test'});
   })
 
   //
   //
-  it("LM_DATA test", function (done) {
+  it("LM_DATA test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_DATA test:'});
     longMessage.channels = []   // clear channels
     let channel = 99
     let testMessage = cbusLib.decode(cbusLib.encodeLM_DATA(channel, 1, 2, 3, 4, 5, 6))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      expect(longMessage.channels[channel]).to.not.be.undefined
-      winston.info({message: logPrefix +': END LM_DATA test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    expect(longMessage.channels[channel]).to.not.be.undefined
+    winston.info({message: logPrefix +': END LM_DATA test'});
   })
 
   //
   //
-  it("LM_END_MESSAGE test", function (done) {
+  it("LM_END_MESSAGE test", function () {
     winston.info({message: logPrefix + ': BEGIN LM_END_MESSAGE test:'});
     longMessage.channels = []   // clear channels
     config.eventBus.once('SERVER_NOTIFICATION', function (data) {
@@ -155,14 +135,11 @@ describe('long message tests', function(){
     let testMessage = cbusLib.decode(cbusLib.encodeLM_END_MESSAGE(channel, checksum))
     winston.info({message: logPrefix +': testMessage ' + JSON.stringify(testMessage)});
     longMessage.processLongMessage(testMessage)
-    setTimeout(function(){
-      winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
-      expect(longMessage.channels[channel]).to.not.be.undefined
-      let currentMessage = longMessage.channels[channel].currentMessage
-      expect(longMessage.channels[channel][currentMessage].checksum).to.equal(checksum)
-      winston.info({message: logPrefix +': END LM_END_MESSAGE test'});
-      done();
-    }, 500);
+    winston.info({message: logPrefix +': channel ' + JSON.stringify(longMessage.channels[channel])});
+    expect(longMessage.channels[channel]).to.not.be.undefined
+    let currentMessage = longMessage.channels[channel].currentMessage
+    expect(longMessage.channels[channel][currentMessage].checksum).to.equal(checksum)
+    winston.info({message: logPrefix +': END LM_END_MESSAGE test'});
   })
 
 

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -64,12 +64,9 @@ describe('mergAdminNode tests', function(){
       node.inUnitTest=true
   });
 
-	after(function(done) {
+	after(function() {
  		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
+    node.dispose()
 	});																										
 
 	afterEach(function() {

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -130,6 +130,86 @@ describe('mergAdminNode tests', function(){
     }
   })
 
+  it("processes incoming CBUS messages sequentially", async function () {
+    const originalActionMessage = node.action_message
+    let resolveFirstAction
+    let signalFirstActionStarted
+    const firstActionStarted = new Promise((resolve) => {
+      signalFirstActionStarted = resolve
+    })
+    let actionCount = 0
+
+    node.action_message = function () {
+      actionCount++
+      if (actionCount == 1) {
+        signalFirstActionStarted()
+        return new Promise((resolve) => {
+          resolveFirstAction = resolve
+        })
+      }
+      return Promise.resolve()
+    }
+
+    const firstHandler = node.gridConnectReceiveHandler(":SB780N0D;")
+    await firstActionStarted
+    const secondHandler = node.gridConnectReceiveHandler(":SB780N0D;")
+
+    try {
+      await Promise.resolve()
+      expect(actionCount).to.equal(1)
+
+      resolveFirstAction()
+      await Promise.all([firstHandler, secondHandler])
+      expect(actionCount).to.equal(2)
+    } finally {
+      if (resolveFirstAction) {
+        resolveFirstAction()
+      }
+      await Promise.allSettled([firstHandler, secondHandler])
+      node.action_message = originalActionMessage
+    }
+  })
+
+  it("continues CBUS processing after an action fails", async function () {
+    const originalActionMessage = node.action_message
+    let rejectFirstAction
+    let signalFirstActionStarted
+    const firstActionStarted = new Promise((resolve) => {
+      signalFirstActionStarted = resolve
+    })
+    let actionCount = 0
+
+    node.action_message = function () {
+      actionCount++
+      if (actionCount == 1) {
+        signalFirstActionStarted()
+        return new Promise((resolve, reject) => {
+          rejectFirstAction = reject
+        })
+      }
+      return Promise.resolve()
+    }
+
+    const firstHandler = node.gridConnectReceiveHandler(":SB780N0D;")
+    await firstActionStarted
+    const secondHandler = node.gridConnectReceiveHandler(":SB780N0D;")
+
+    try {
+      await Promise.resolve()
+      expect(actionCount).to.equal(1)
+
+      rejectFirstAction(new Error("action failed"))
+      await Promise.all([firstHandler, secondHandler])
+      expect(actionCount).to.equal(2)
+    } finally {
+      if (rejectFirstAction) {
+        rejectFirstAction(new Error("action failed"))
+      }
+      await Promise.allSettled([firstHandler, secondHandler])
+      node.action_message = originalActionMessage
+    }
+  })
+
   function GetTestCase_events_with_type() {
     var arg1, arg2, arg3, testCases = [];
     for (var a = 1; a<= 3; a++) {

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -1009,6 +1009,8 @@ describe('mergAdminNode tests', function(){
     node.createNodeConfig(value.nodeNumber)    // create node config for node we're testing
     node.nodeConfig.nodes[value.nodeNumber].VLCB = true
     node.nodeConfig.nodes[value.nodeNumber].parameters[5] = 2
+    node.nodeConfig.nodes[value.nodeNumber].storedEventsNI = {}
+    node.nodeConfig.nodes[value.nodeNumber].eventsByIndex = {}
     node.updateEventInNodeConfig(value.nodeNumber, value.eventIdentifier, value.eventIndex)
     winston.info({message: 'unit_test: storedEventsNI ' + JSON.stringify(node.nodeConfig.nodes[value.nodeNumber].storedEventsNI, null, " ")});
     winston.info({message: 'unit_test: eventsByIndex ' + JSON.stringify(node.nodeConfig.nodes[value.nodeNumber].eventsByIndex, null, " ")});
@@ -1667,23 +1669,22 @@ describe('mergAdminNode tests', function(){
 
   // reset_node test
   //
-  it("reset_node test", function (done) {
+  it("reset_node test", async function () {
     winston.info({message: 'unit_test: BEGIN reset_node test: '});
     mock_messageRouter.messagesIn = []
     let nodeNumber = 1
-    node.reset_node(nodeNumber) 
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NNRST")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("RQNPN")
-      expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("MODE")
-      winston.info({message: 'unit_test: END reset_node test'});
-			done();
-		}, 1000);
+    node.reset_node(nodeNumber)
+    await waitForCBUSMessages(3)
+
+    for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
+      winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
+    }
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NNRST")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("RQNPN")
+    expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("MODE")
+    winston.info({message: 'unit_test: END reset_node test'});
   })
 
 

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -88,6 +88,15 @@ describe('mergAdminNode tests', function(){
     return testCases;
   }
 
+  async function waitForCBUSMessages(expectedCount, timeoutMs = 2000) {
+    const timeout = Date.now() + timeoutMs
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < expectedCount) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn.length).to.equal(expectedCount)
+  }
+
   function GetTestCase_events_with_type() {
     var arg1, arg2, arg3, testCases = [];
     for (var a = 1; a<= 3; a++) {
@@ -160,17 +169,15 @@ describe('mergAdminNode tests', function(){
   
   // 0x0D QNN
   //
-  it("query_all_nodes test ", function (done) {
+  it("query_all_nodes test ", async function () {
     winston.info({message: 'unit_test: BEGIN query_all_nodes test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.query_all_nodes()
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('QNN')
-      winston.info({message: 'unit_test: END query_all_nodes test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('QNN')
+    winston.info({message: 'unit_test: END query_all_nodes test'});
   })
 
   // 0x11 RQMN
@@ -178,223 +185,197 @@ describe('mergAdminNode tests', function(){
 
   // 0x42 sendSNN
   //
-  itParam("sendSNN test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), function (done, value) {
+  itParam("sendSNN test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN sendSNN test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendSNN(value.nodeNumber)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('SNN')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      winston.info({message: 'unit_test: END sendSNN test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('SNN')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END sendSNN test'});
   })
 
   // 0x5D sendENUM
   //
-  itParam("sendENUM test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), function (done, value) {
+  itParam("sendENUM test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN sendENUM test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendENUM(value.nodeNumber)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ENUM')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      winston.info({message: 'unit_test: END sendENUM test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ENUM')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END sendENUM test'});
   })
 
   // 0x5E sendNNRST
   //
-  itParam("sendNNRST test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), function (done, value) {
+  itParam("sendNNRST test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN sendNNRST test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendNNRST(value.nodeNumber)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNRST')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      winston.info({message: 'unit_test: END sendNNRST test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNRST')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END sendNNRST test'});
   })
 
   // 0x73 sendRQNPN
   //
-  it("sendRQNPN test", function (done) {
+  it("sendRQNPN test", async function () {
     winston.info({message: 'unit_test: BEGIN sendRQNPN test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendRQNPN(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(2)
-      winston.info({message: 'unit_test: END sendRQNPN test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(2)
+    winston.info({message: 'unit_test: END sendRQNPN test'});
   })
 
   // 0x75 sendCANID
   //
-  it("sendCANID test", function (done) {
+  it("sendCANID test", async function () {
     winston.info({message: 'unit_test: BEGIN sendCANID test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendCANID(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('CANID')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].CAN_ID).to.equal(2)
-      winston.info({message: 'unit_test: END sendCANID test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('CANID')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].CAN_ID).to.equal(2)
+    winston.info({message: 'unit_test: END sendCANID test'});
   })
 
   // 0x75 sendRQSD
   //
-  it("sendRQSD test", function (done) {
+  it("sendRQSD test", async function () {
     winston.info({message: 'unit_test: BEGIN sendRQSD test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendRQSD(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQSD')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].ServiceIndex).to.equal(2)
-      winston.info({message: 'unit_test: END sendRQSD test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQSD')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].ServiceIndex).to.equal(2)
+    winston.info({message: 'unit_test: END sendRQSD test'});
   })
 
   // 0x87 sendRDGN
   //
-  it("sendRDGN test", function (done) {
+  it("sendRDGN test", async function () {
     winston.info({message: 'unit_test: BEGIN sendRDGN test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendRDGN(1, 2, 3)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RDGN')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].ServiceIndex).to.equal(2)
-      expect(mock_messageRouter.messagesIn[0].DiagnosticCode).to.equal(3)
-      winston.info({message: 'unit_test: END sendRDGN test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RDGN')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].ServiceIndex).to.equal(2)
+    expect(mock_messageRouter.messagesIn[0].DiagnosticCode).to.equal(3)
+    winston.info({message: 'unit_test: END sendRDGN test'});
   })
 
   // 0x90 sendACON
   //
-  it("sendACON test", function (done) {
+  it("sendACON test", async function () {
     winston.info({message: 'unit_test: BEGIN sendACON test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendACON(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ACON')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].eventNumber).to.equal(2)
-      winston.info({message: 'unit_test: END sendACON test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ACON')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].eventNumber).to.equal(2)
+    winston.info({message: 'unit_test: END sendACON test'});
   })
 
   // 0x91 sendACOF
   //
-  it("sendACOF test", function (done) {
+  it("sendACOF test", async function () {
     winston.info({message: 'unit_test: BEGIN sendACOF test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendACOF(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ACOF')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].eventNumber).to.equal(2)
-      winston.info({message: 'unit_test: END sendACOF test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ACOF')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].eventNumber).to.equal(2)
+    winston.info({message: 'unit_test: END sendACOF test'});
   })
 
   // 0x96 sendNVSET
   //
-  it("sendNVSET test", function (done) {
+  it("sendNVSET test", async function () {
     winston.info({message: 'unit_test: BEGIN sendNVSET test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendNVSET(1, 2, 3)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NVSET')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].nodeVariableIndex).to.equal(2)
-      expect(mock_messageRouter.messagesIn[0].nodeVariableValue).to.equal(3)
-      winston.info({message: 'unit_test: END sendNVSET test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NVSET')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].nodeVariableIndex).to.equal(2)
+    expect(mock_messageRouter.messagesIn[0].nodeVariableValue).to.equal(3)
+    winston.info({message: 'unit_test: END sendNVSET test'});
   })
 
   // 0x98 sendASON
   //
-  it("sendASON test", function (done) {
+  it("sendASON test", async function () {
     winston.info({message: 'unit_test: BEGIN sendASON test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendASON(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ASON')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].deviceNumber).to.equal(2)
-      winston.info({message: 'unit_test: END sendASON test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ASON')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].deviceNumber).to.equal(2)
+    winston.info({message: 'unit_test: END sendASON test'});
   })
 
   // 0x99 sendASOF
   //
-  it("sendASOF test", function (done) {
+  it("sendASOF test", async function () {
     winston.info({message: 'unit_test: BEGIN sendASOF test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendASOF(1, 2)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ASOF')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].deviceNumber).to.equal(2)
-      winston.info({message: 'unit_test: END sendASOF test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('ASOF')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].deviceNumber).to.equal(2)
+    winston.info({message: 'unit_test: END sendASOF test'});
   })
 
   // 0x9C sendREVAL
   //
-  it("sendREVAL test", function (done) {
+  it("sendREVAL test", async function () {
     winston.info({message: 'unit_test: BEGIN sendREVAL test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
     node.sendREVAL(1, 2, 3)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
-      expect(mock_messageRouter.messagesIn[0].eventIndex).to.equal(2)
-      expect(mock_messageRouter.messagesIn[0].eventVariableIndex).to.equal(3)
-      winston.info({message: 'unit_test: END sendREVAL test'});
-      done();
-    }, 10);
+    await waitForCBUSMessages(1)
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn[0])}`});
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(1)
+    expect(mock_messageRouter.messagesIn[0].eventIndex).to.equal(2)
+    expect(mock_messageRouter.messagesIn[0].eventVariableIndex).to.equal(3)
+    winston.info({message: 'unit_test: END sendREVAL test'});
   })
 
   //****************************************************************************************** */
@@ -1146,7 +1127,7 @@ describe('mergAdminNode tests', function(){
 
   // update_node_variable_in_learnMode test
   //
-  it("update_node_variable_in_learnMode test", function (done) {
+  it("update_node_variable_in_learnMode test", async function () {
     winston.info({message: 'unit_test: BEGIN update_node_variable_in_learnMode test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
@@ -1154,17 +1135,15 @@ describe('mergAdminNode tests', function(){
     let nodeVariableIndex = 2
     let nodeVariableValue = 3
     node.update_node_variable_in_learnMode(nodeNumber, nodeVariableIndex, nodeVariableValue)
-    setTimeout(function(){
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNLRN')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('NVSET')
-      expect(mock_messageRouter.messagesIn[1].nodeVariableIndex).to.equal(nodeVariableIndex)
-      expect(mock_messageRouter.messagesIn[1].nodeVariableValue).to.equal(nodeVariableValue)
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('NNULN')
-      expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(nodeNumber)
-      winston.info({message: 'unit_test: END update_node_variable_in_learnMode test'});
-      done();
-    }, 80);
+    await waitForCBUSMessages(3)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNLRN')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('NVSET')
+    expect(mock_messageRouter.messagesIn[1].nodeVariableIndex).to.equal(nodeVariableIndex)
+    expect(mock_messageRouter.messagesIn[1].nodeVariableValue).to.equal(nodeVariableValue)
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('NNULN')
+    expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(nodeNumber)
+    winston.info({message: 'unit_test: END update_node_variable_in_learnMode test'});
   })
 
 
@@ -1385,90 +1364,66 @@ describe('mergAdminNode tests', function(){
 
   // request_all_node_events test
   //
-  itParam("request_all_node_events test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (done, value) {
+  itParam("request_all_node_events test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN request_all_node_events test: ' + JSON.stringify(value) });
     
     mock_messageRouter.messagesIn = []
 
-    await node.request_all_node_events(value.nodeNumber) 
-  
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("RQEVN")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      winston.info({message: 'unit_test: END request_all_node_events test'});
-			done();
-		}, 30);
+    await node.request_all_node_events(value.nodeNumber)
+    await waitForCBUSMessages(1)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("RQEVN")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END request_all_node_events test'});
 
   })
 
   // request_all_node_events_by_index test
   //
-  itParam("request_all_node_events_by_index test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (done, value) {
+  itParam("request_all_node_events_by_index test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN request_all_node_events_by_index test: ' + JSON.stringify(value) });
     
     mock_messageRouter.messagesIn = []
 
-    await node.request_all_node_events_by_index(value.nodeNumber, 2) 
-  
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NENRD")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("NENRD")
-      expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(value.nodeNumber)
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("RQEVN")
-      expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(value.nodeNumber)    
-      winston.info({message: 'unit_test: END request_all_node_events_by_index test'});
-			done();
-		}, 100);
+    await node.request_all_node_events_by_index(value.nodeNumber, 2)
+    await waitForCBUSMessages(3)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NENRD")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("NENRD")
+    expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(value.nodeNumber)
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("RQEVN")
+    expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END request_all_node_events_by_index test'});
 
   })
 
   // request_node_event_by_index test
   //
-  itParam("request_node_event_by_index test ${JSON.stringify(value)}", GetTestCase_eventIndex(), function (done, value) {
-  //it("request_node_event_by_index test", function (done) {
+  itParam("request_node_event_by_index test ${JSON.stringify(value)}", GetTestCase_eventIndex(), async function (value) {
     winston.info({message: 'unit_test: BEGIN request_node_event_by_index test: '});
     
     mock_messageRouter.messagesIn = []
 
-    node.request_node_event_by_index(value.nodeNumber, value.eventIndex) 
-  
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NENRD")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      expect(mock_messageRouter.messagesIn[0].eventIndex).to.equal(value.eventIndex)
-      winston.info({message: 'unit_test: END request_node_event_by_index test'});
-			done();
-		}, 30);
+    await node.request_node_event_by_index(value.nodeNumber, value.eventIndex)
+    await waitForCBUSMessages(1)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NENRD")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    expect(mock_messageRouter.messagesIn[0].eventIndex).to.equal(value.eventIndex)
+    winston.info({message: 'unit_test: END request_node_event_by_index test'});
 
   })
 
   // request_all_node_parameters test
   //
-  it("request_all_node_parameters test", function (done) {
+  it("request_all_node_parameters test", async function () {
     winston.info({message: 'unit_test: BEGIN request_all_node_parameters test: '});
     mock_messageRouter.messagesIn = []
     let nodeNumber = 1
-    node.request_all_node_parameters(nodeNumber) 
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("RQNPN")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(0)
-      winston.info({message: 'unit_test: END request_all_node_parameters test'});
-			done();
-		}, 30);
+    await node.request_all_node_parameters(nodeNumber)
+    await waitForCBUSMessages(1)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("RQNPN")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(0)
+    winston.info({message: 'unit_test: END request_all_node_parameters test'});
   })
 
 
@@ -1520,20 +1475,15 @@ describe('mergAdminNode tests', function(){
   //
   //
   //
-  itParam("request_node_variable test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (done, value) {
+  itParam("request_node_variable test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN request_node_variable test: ' + JSON.stringify(value) });
     mock_messageRouter.messagesIn = []
-    await node.request_node_variable(value.nodeNumber, 2) 
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NVRD")
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
-      expect(mock_messageRouter.messagesIn[0].nodeVariableIndex).to.equal(2)
-      winston.info({message: 'unit_test: END request_node_variable test'});
-			done();
-		}, 500);
+    await node.request_node_variable(value.nodeNumber, 2)
+    await waitForCBUSMessages(1)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NVRD")
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(value.nodeNumber)
+    expect(mock_messageRouter.messagesIn[0].nodeVariableIndex).to.equal(2)
+    winston.info({message: 'unit_test: END request_node_variable test'});
 
   })
 

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -94,6 +94,42 @@ describe('mergAdminNode tests', function(){
     expect(mock_messageRouter.messagesIn.length).to.equal(expectedCount)
   }
 
+  it("gridConnectReceiveHandler waits for action processing", async function () {
+    const originalActionMessage = node.action_message
+    let resolveAction
+    let signalActionStarted
+    const actionStarted = new Promise((resolve) => {
+      signalActionStarted = resolve
+    })
+
+    node.action_message = function () {
+      signalActionStarted()
+      return new Promise((resolve) => {
+        resolveAction = resolve
+      })
+    }
+
+    let handlerCompleted = false
+    const handlerPromise = node.gridConnectReceiveHandler(":SB780N0D;")
+    handlerPromise.then(() => {
+      handlerCompleted = true
+    })
+
+    try {
+      await actionStarted
+      await Promise.resolve()
+      expect(handlerCompleted).to.equal(false)
+
+      resolveAction()
+      await handlerPromise
+    } finally {
+      if (resolveAction) {
+        resolveAction()
+      }
+      node.action_message = originalActionMessage
+    }
+  })
+
   function GetTestCase_events_with_type() {
     var arg1, arg2, arg3, testCases = [];
     for (var a = 1; a<= 3; a++) {

--- a/unit_tests/mergAdminNode.spec.js
+++ b/unit_tests/mergAdminNode.spec.js
@@ -875,7 +875,7 @@ describe('mergAdminNode tests', function(){
   // initial REVAL should return number of subsequent EV's which should then be requested
   // so check the number of REVAL's is correct - should be 3 in total
   //
-  itParam("requestAllEventVariablesByIdentifier test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (done, value) {
+  itParam("requestAllEventVariablesByIdentifier test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (value) {
     winston.info({message: 'unit_test: BEGIN requestAllEventVariablesByIdentifier test ' + JSON.stringify(value)});
     // ensure event does exist with correct eventIndex
     node.createNodeConfig(value.nodeNumber)    // create node config for node we're testing
@@ -885,19 +885,23 @@ describe('mergAdminNode tests', function(){
     winston.info({message: 'unit_test: eventsByIndex ' + JSON.stringify(node.nodeConfig.nodes[value.nodeNumber].eventsByIndex, null, " ")});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
-    node.requestAllEventVariablesByIdentifier(value.nodeNumber, value.eventIdentifier)
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NERD')
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn.length).to.equal(4)
-      winston.info({message: 'unit_test: END requestAllEventVariablesByIdentifier test '});
-      done();
-    }, 200);
+    await node.requestAllEventVariablesByIdentifier(value.nodeNumber, value.eventIdentifier)
+
+    const timeout = Date.now() + 2000
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < 4) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+
+    for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
+      winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NERD')
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn.length).to.equal(4)
+    winston.info({message: 'unit_test: END requestAllEventVariablesByIdentifier test '});
   })
 
   //
@@ -905,7 +909,7 @@ describe('mergAdminNode tests', function(){
   // initial REQEV should return number of subsequent EV's
   // so check the number of REVAL's is correct - should be 3 in total
   //
-  itParam("requestAllEventVariablesByIdentifier_VLCB test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (done, value) {
+  itParam("requestAllEventVariablesByIdentifier_VLCB test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (value) {
     winston.info({message: 'unit_test: BEGIN requestAllEventVariablesByIdentifier_VLCB test ' + JSON.stringify(value)});
     // ensure event does exist with correct eventIndex
     node.createNodeConfig(value.nodeNumber)    // create node config for node we're testing
@@ -916,18 +920,22 @@ describe('mergAdminNode tests', function(){
     winston.info({message: 'unit_test: eventsByIndex ' + JSON.stringify(node.nodeConfig.nodes[value.nodeNumber].eventsByIndex, null, " ")});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
-    node.requestAllEventVariablesByIdentifier(value.nodeNumber, value.eventIdentifier)
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNLRN')
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REQEV')
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('NNULN')
-      expect(mock_messageRouter.messagesIn.length).to.equal(9)
-      winston.info({message: 'unit_test: END requestAllEventVariablesByIdentifier_VLCB test '});
-      done();
-    }, 250);
+    await node.requestAllEventVariablesByIdentifier(value.nodeNumber, value.eventIdentifier)
+
+    const timeout = Date.now() + 2000
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < 9) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+
+    for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
+      winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('NNLRN')
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REQEV')
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('NNULN')
+    expect(mock_messageRouter.messagesIn.length).to.equal(9)
+    winston.info({message: 'unit_test: END requestAllEventVariablesByIdentifier_VLCB test '});
   })
 
   //
@@ -936,7 +944,7 @@ describe('mergAdminNode tests', function(){
   // so check the number of REVAL's is correct - should be 3 in total
   // response to REVAL - NEVAL is tested elsewhere
   //
-  itParam("requestAllEventVariablesByIndex test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (done, value) {
+  itParam("requestAllEventVariablesByIndex test ${JSON.stringify(value)}", GetTestCase_events_with_identifier(), async function (value) {
     winston.info({message: 'unit_test: BEGIN requestAllEventVariablesByIndex test ' + JSON.stringify(value)});
     // ensure event does exist with correct eventIndex
     node.createNodeConfig(value.nodeNumber)    // create node config for node we're testing
@@ -946,18 +954,22 @@ describe('mergAdminNode tests', function(){
     winston.info({message: 'unit_test: eventsByIndex ' + JSON.stringify(node.nodeConfig.nodes[value.nodeNumber].eventsByIndex, null, " ")});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
-    node.requestAllEventVariablesByIndex(value.nodeNumber, value.eventIndex)
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('REVAL')
-      expect(mock_messageRouter.messagesIn.length).to.equal(3)
-      winston.info({message: 'unit_test: END requestAllEventVariablesByIndex test '});
-      done();
-    }, 200);
+    await node.requestAllEventVariablesByIndex(value.nodeNumber, value.eventIndex)
+
+    const timeout = Date.now() + 2000
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < 3) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+
+    for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
+      winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('REVAL')
+    expect(mock_messageRouter.messagesIn.length).to.equal(3)
+    winston.info({message: 'unit_test: END requestAllEventVariablesByIndex test '});
   })
 
   // request_all_node_variables
@@ -1085,7 +1097,7 @@ describe('mergAdminNode tests', function(){
   // use a new node number
   // and a message that isn't PNN
   //
-  it("postOpcodeProcessing test", function (done) {
+  it("postOpcodeProcessing test", async function () {
     winston.info({message: 'unit_test: BEGIN postOpcodeProcessing test '});
     mock_messageRouter.messagesIn = []
     nodeTraffic = []
@@ -1095,30 +1107,40 @@ describe('mergAdminNode tests', function(){
     node.createNodeConfig(nodeNumber, false)
     // round trip to get json decode
     let cbusmsg = cbusLib.decode(cbusLib.encodeWRACK(nodeNumber))
-    node.postOpcodeProcessing(cbusmsg)
-    setTimeout(function(){
-      winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn)}`});
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(8)
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[1].parameterIndex).to.equal(1)
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[2].parameterIndex).to.equal(3)
-      expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[3].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[3].parameterIndex).to.equal(7)
-      expect(mock_messageRouter.messagesIn[4].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[4].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[4].parameterIndex).to.equal(2)
-      expect(mock_messageRouter.messagesIn[5].mnemonic).to.equal('RQNPN')
-      expect(mock_messageRouter.messagesIn[5].nodeNumber).to.equal(nodeNumber)
-      expect(mock_messageRouter.messagesIn[5].parameterIndex).to.equal(9)
-      winston.info({message: 'unit_test: END postOpcodeProcessing test'});
-      done();
-    }, 500);
+    await node.postOpcodeProcessing(cbusmsg)
+
+    const timeout = Date.now() + 2000
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < 8) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+
+    winston.info({message: `unit_test: result ${JSON.stringify(mock_messageRouter.messagesIn)}`});
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[0].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[0].parameterIndex).to.equal(8)
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[1].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[1].parameterIndex).to.equal(1)
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[2].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[2].parameterIndex).to.equal(3)
+    expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[3].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[3].parameterIndex).to.equal(7)
+    expect(mock_messageRouter.messagesIn[4].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[4].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[4].parameterIndex).to.equal(2)
+    expect(mock_messageRouter.messagesIn[5].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[5].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[5].parameterIndex).to.equal(9)
+    expect(mock_messageRouter.messagesIn[6].mnemonic).to.equal('RQNPN')
+    expect(mock_messageRouter.messagesIn[6].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn[6].parameterIndex).to.equal(20)
+    expect(mock_messageRouter.messagesIn[7].mnemonic).to.equal('RQEVN')
+    expect(mock_messageRouter.messagesIn[7].nodeNumber).to.equal(nodeNumber)
+    expect(mock_messageRouter.messagesIn.length).to.equal(8)
+    winston.info({message: 'unit_test: END postOpcodeProcessing test'});
   })
 
 
@@ -1337,27 +1359,28 @@ describe('mergAdminNode tests', function(){
   //
   //
   //
-  itParam("requestAllEventVariablesForNode test ${JSON.stringify(value)}", GetTestCase_nodeFlags(), async function (done, value) {
-    //it("requestAllEventVariablesForNode", function (done) {
+  itParam("requestAllEventVariablesForNode test ${JSON.stringify(value)}", GetTestCase_nodeFlags(), async function (value) {
     winston.info({message: `unit_test: BEGIN requestAllEventVariablesForNode test: ${JSON.stringify(value)}` });   
-//    mock_messageRouter.messagesIn = []
-//    nodeTraffic=[]
+    mock_messageRouter.messagesIn = []
+    nodeTraffic=[]
     mock_messageRouter.FCU_Compatability = value.FCU_Compatability
     node.updateEventInNodeConfig(value.nodeNumber, "00001111", 1)
     node.updateEventInNodeConfig(value.nodeNumber, "00002222", 2)
     node.nodeConfig.nodes[value.nodeNumber].parameters[5] = 2       // two events
     node.nodeConfig.nodes[value.nodeNumber].VLCB = value.VLCB
-    node.requestAllEventVariablesForNode(value.nodeNumber) 
-  
-    setTimeout(function(){
-      for (let i = 0; i < nodeTraffic.length; i++) {
-        //winston.info({message: `unit_test: nodeTraffic ${JSON.stringify(nodeTraffic[i])}`});
-        winston.info({message: `unit_test: nodeTraffic  ${nodeTraffic[i].direction} ${nodeTraffic[i].json.encoded} ${nodeTraffic[i].json.text}`});
-      }
-      expect(nodeTraffic.length).to.equal(value.count)
-      winston.info({message: 'unit_test: END requestAllEventVariablesForNode test'});
-			done();
-		}, 1000);
+    await node.requestAllEventVariablesForNode(value.nodeNumber)
+
+    const timeout = Date.now() + 2000
+    while ((node.CBUS_Queue.length > 0 || nodeTraffic.length < value.count) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+
+    for (let i = 0; i < nodeTraffic.length; i++) {
+      winston.info({message: `unit_test: nodeTraffic  ${nodeTraffic[i].direction} ${nodeTraffic[i].json.encoded} ${nodeTraffic[i].json.text}`});
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(nodeTraffic.length).to.equal(value.count)
+    winston.info({message: 'unit_test: END requestAllEventVariablesForNode test'});
   })
 
   // request_all_node_events test
@@ -1605,4 +1628,3 @@ describe('mergAdminNode tests', function(){
 
 
 })
-

--- a/unit_tests/messageRouter.spec.js
+++ b/unit_tests/messageRouter.spec.js
@@ -22,17 +22,15 @@ const name = 'unit_test: messageRouter'
   
 describe('messageRouter tests', function(){
 
-  messageRouter.connect('localhost', cbusServerPort)
-
-	before(function(done) {
+	before(async function() {
 		winston.info({message: ' '});
 		winston.info({message: '================================================================================'});
     //                      12345678901234567890123456789012345678900987654321098765432109876543210987654321
 		winston.info({message: '----------------------------- messageRouter tests ------------------------------'});
 		winston.info({message: '================================================================================'});
 		winston.info({message: ' '});
-    //
-		done();
+    await mock_cbusServer.listening
+    messageRouter.connect('localhost', cbusServerPort)
 	});
 
 	beforeEach(function() {
@@ -41,12 +39,10 @@ describe('messageRouter tests', function(){
         // ensure expected CAN header is reset before each test run
 	});
 
-	after(function(done) {
+	after(async function() {
  		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
+    await messageRouter.close()
+    await mock_cbusServer.close()
 	});																										
 
 

--- a/unit_tests/messageRouter.spec.js
+++ b/unit_tests/messageRouter.spec.js
@@ -30,7 +30,7 @@ describe('messageRouter tests', function(){
 		winston.info({message: '================================================================================'});
 		winston.info({message: ' '});
     await mock_cbusServer.listening
-    messageRouter.connect('localhost', cbusServerPort)
+    await messageRouter.connect('localhost', cbusServerPort)
 	});
 
 	beforeEach(function() {
@@ -51,6 +51,21 @@ describe('messageRouter tests', function(){
   // Actual tests after here...
   //
   //****************************************************************************************** */  
+
+
+  it("connect waits for the TCP connection", async function () {
+    const testCbusServer = new (require('./mock_cbusServer'))(0)
+    const testMessageRouter = require('../VLCB-server/messageRouter.js')(config)
+    const address = await testCbusServer.listening
+
+    try {
+      await testMessageRouter.connect('localhost', address.port)
+      expect(testMessageRouter.connected).to.equal(true)
+    } finally {
+      await testMessageRouter.close()
+      await testCbusServer.close()
+    }
+  })
 
 
   it("sendCbusMessage test", function (done) {

--- a/unit_tests/mock_cbusServer.js
+++ b/unit_tests/mock_cbusServer.js
@@ -9,12 +9,12 @@ class mock_cbusServer{
   constructor(CBUS_SERVER_PORT) {
     winston.info({message:name + `: Constructor - Port ` + CBUS_SERVER_PORT})
 
-    this.clients = [];
+    this.clients = new Set();
     this.messagesIn = [];
 
-    const server = net.createServer(function (socket) {
+    this.server = net.createServer(function (socket) {
       socket.setKeepAlive(true, 60000);
-      this.clients.push(socket);
+      this.clients.add(socket);
       winston.info({message:name + `: remote Client Connected: ` + JSON.stringify(socket.address())})
 
       socket.on('connect', function () {
@@ -30,9 +30,19 @@ class mock_cbusServer{
         winston.info({message:name + `: On error Received :`})
       }.bind(this));
 
+      socket.on('close', function () {
+        this.clients.delete(socket)
+      }.bind(this));
+
     }.bind(this));
 
-    server.listen(CBUS_SERVER_PORT)
+    this.listening = new Promise((resolve, reject) => {
+      this.server.once('error', reject)
+      this.server.listen(CBUS_SERVER_PORT, () => {
+        this.server.removeListener('error', reject)
+        resolve(this.server.address())
+      })
+    })
   } // end constructor
 
   // this accepts gridconnect data
@@ -47,8 +57,22 @@ class mock_cbusServer{
     });
   }
 
+  async close(){
+    for (const client of this.clients) {
+      client.destroy()
+    }
+    this.clients.clear()
+
+    if (!this.server.listening) {
+      return
+    }
+
+    await new Promise((resolve, reject) => {
+      this.server.close((error) => error ? reject(error) : resolve())
+    })
+  }
+
 
 }
 
 module.exports = mock_cbusServer;
-

--- a/unit_tests/programNode.spec.js
+++ b/unit_tests/programNode.spec.js
@@ -4,7 +4,6 @@ const path = require('path');
 const expect = require('chai').expect;
 var itParam = require('mocha-param');
 const fs = require('fs');
-const utils = require('../VLCB-server/utilities.js');
 
 const cbusLib = require('cbuslibrary')
 
@@ -28,14 +27,12 @@ const programNode = require('../VLCB-server/programNodeMMC.js')(config)
 describe('programNode tests', async function(){
     
 
-  before(async function(done) {
+  before(function() {
 		winston.info({message: ' '});
 		winston.info({message: '======================================================================'});
 		winston.info({message: '------------------------ Program Node tests --------------------------'});
 		winston.info({message: '======================================================================'});
 		winston.info({message: ' '});
-      done();
-      await utils.sleep(1000) // allow time for clients to connect
   	});
     
     beforeEach(function() {
@@ -47,12 +44,13 @@ describe('programNode tests', async function(){
       mock_messageRouter.messagesIn = []
     })
 
-	after(function(done) {
-   		winston.info({message: ' '});   // blank line to separate tests
-        setTimeout(() => {
-            winston.debug({message: 'UNIT_TEST: programNode: Tests ended'});
-            done();
-        }, 500)
+	afterEach(function() {
+    programNode.removeAllListeners('programNode_progress')
+	})
+
+	after(function() {
+		winston.info({message: ' '});   // blank line to separate tests
+		winston.debug({message: 'UNIT_TEST: programNode: Tests ended'});
 	});																										
 	
 	//
@@ -200,9 +198,12 @@ describe('programNode tests', async function(){
   //
   // Use real hex file to ensure correct operation
   //
-  it('send_bootloader_data test', function(done) {
+  it('send_bootloader_data test', async function() {
     winston.info({message: 'UNIT_TEST: >>>>>> BEGIN: send_bootloader_data test:'});
     programNode.setCpuType(23)
+    programNode.BOOTLOADER_DATA_BLOCKS = []
+    programNode.calculatedHexChecksum = '0000'
+    programNode.dataCount = 0
     programNode.BOOTLOADER_DATA_BLOCKS[0] = [1, 2, 3, 4, 5, 6, 7, 8]
     programNode.BOOTLOADER_DATA_BLOCKS[0x820] = [0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18]
     programNode.BOOTLOADER_DATA_BLOCKS[0x828] = [0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18]
@@ -210,14 +211,9 @@ describe('programNode tests', async function(){
     programNode.BOOTLOADER_DATA_BLOCKS[0x800] = [0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18]
     programNode.BOOTLOADER_DATA_BLOCKS[0x300000] = [0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28]
     programNode.BOOTLOADER_DATA_BLOCKS[0xF00000] = [0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38]
-    programNode.send_bootloader_data(1)
-    // as we're testing this function outside the event handling, allow some time for events to be received
-    // before moving onto next test
-    setTimeout(() => {
-      //expect(result).to.equal(true);
-      winston.info({message: 'UNIT_TEST: <<<<<< END: send_bootloader_data test:'});
-      done();
-    }, 1100)
+    await programNode.send_bootloader_data(1)
+    expect(mock_messageRouter.messagesIn.length).to.be.above(0)
+    winston.info({message: 'UNIT_TEST: <<<<<< END: send_bootloader_data test:'});
   });
 
 
@@ -300,9 +296,7 @@ describe('programNode tests', async function(){
     expect(lastMsg.type).to.equal('CONTROL', 'last message control type');
     expect(lastMsg.SPCMD).to.equal(1, 'last message reset command');
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: END program short:'});
-    await utils.sleep(1100)
 	});
 
 
@@ -404,9 +398,7 @@ describe('programNode tests', async function(){
     expect(corruptFileData.status).to.equal("Failure", 'Download event');
     expect(corruptFileData.text).to.equal("Failed: file parsing failed", 'Download event');
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: <<<<<< END: corrupt download:'});
-    await utils.sleep(1100)
 	});
 
 
@@ -441,9 +433,7 @@ describe('programNode tests', async function(){
       expect(downloadData.text).to.equal('CPU mismatch', 'Download event');
     }
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: END: CPUTYPE:'});
-    await utils.sleep(1100)
 	});
 
 
@@ -465,9 +455,7 @@ describe('programNode tests', async function(){
     expect(downloadDataArray[downloadDataArray.length-1].status).to.equal('Success', 'Download event');
     expect(downloadDataArray[downloadDataArray.length-1].text).to.equal('Success: programing completed', 'Download event');
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: <<<<<< END: ignore CPUTYPE:'});
-    await utils.sleep(1100)
 	});
 
 
@@ -507,9 +495,7 @@ describe('programNode tests', async function(){
     expect(lastMsg.type).to.equal('CONTROL', 'last message control type');
     expect(lastMsg.SPCMD).to.equal(1, 'last message reset command');
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: <<<<<< END: programBootMode:'});
-    await utils.sleep(1100)
 	});
 
   //
@@ -552,9 +538,7 @@ describe('programNode tests', async function(){
     expect(lastMsg.type).to.equal('CONTROL', 'last message control type');
     expect(lastMsg.SPCMD).to.equal(1, 'last message reset command');
     //
-    programNode.removeAllListeners('programNode_progress');
     winston.info({message: 'UNIT_TEST: END program full download:'});
-    await utils.sleep(1100)
   });
 
 })

--- a/unit_tests/serialGC.spec.js
+++ b/unit_tests/serialGC.spec.js
@@ -17,10 +17,21 @@ describe('serialGC tests', function(){
 
   let messageIn = null
 
-  serialGC.on('data', function (data) {
+  async function connectMockSerialPort() {
+    await serialGC.connect("MOCK_PORT")
+    if (!serialGC.serialPort.isOpen) {
+      await new Promise((resolve, reject) => {
+        serialGC.serialPort.once('open', resolve)
+        serialGC.serialPort.once('error', reject)
+      })
+    }
+  }
+
+  function dataHandler(data) {
     winston.info({message: name + `: emitted:  ${JSON.stringify(data)}`})
     messageIn = data
-  })
+  }
+  serialGC.on('data', dataHandler)
   
 
 	before(function(done) {
@@ -41,13 +52,14 @@ describe('serialGC tests', function(){
         // ensure expected CAN header is reset before each test run
 	});
 
-	after(function(done) {
+	after(function() {
  		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
+    serialGC.removeListener('data', dataHandler)
 	});																										
+
+	afterEach(async function() {
+    await serialGC.close()
+	});
 
 
   //****************************************************************************************** */
@@ -58,39 +70,31 @@ describe('serialGC tests', function(){
 
   //
   //
-  it("serialGC_RX test ", function (done) {
+  it("serialGC_RX test ", async function () {
     winston.info({message: 'unit_test: BEGIN serialGC_RX test '});
-    serialGC.connect("MOCK_PORT")
-
-    setTimeout(function(){
-      // emulate some data being received on serialPort
-      let testPattern = ":SB780N0D;"
-      serialGC.serialPort.port.emitData(testPattern)
-
-      setTimeout(function(){
-        expect(messageIn).to.equal(testPattern)
-        winston.info({message: name +': END serialGC_RX test'});
-        done();
-      }, 20);
-    }, 20);
+    await connectMockSerialPort()
+    let testPattern = ":SB780N0D;"
+    const receivedData = new Promise((resolve) => serialGC.once('data', resolve))
+    serialGC.serialPort.port.emitData(testPattern)
+    await receivedData
+    expect(messageIn).to.equal(testPattern)
+    winston.info({message: name +': END serialGC_RX test'});
 
   })
 
   //
   //
-  it("serialGC_TX test ", function (done) {
+  it("serialGC_TX test ", async function () {
     winston.info({message: 'unit_test: BEGIN serialGC_TX test '});
-    serialGC.connect("MOCK_PORT")
+    await connectMockSerialPort()
     let testPattern = ":SB780N0D;"
-    setTimeout(function(){
-      serialGC.write(testPattern)
-      setTimeout(function(){        
-        winston.info({message: name +`: END serial TX ${serialGC.serialPort.port.recording}`});
-        expect(serialGC.serialPort.port.recording.toString()).to.equal(testPattern)
-        winston.info({message: name +': END serialGC_TX test'});
-        done();
-      }, 10);
-    }, 10);
+    serialGC.write(testPattern)
+    await new Promise((resolve, reject) => {
+      serialGC.serialPort.drain((error) => error ? reject(error) : resolve())
+    })
+    winston.info({message: name +`: END serial TX ${serialGC.serialPort.port.recording}`});
+    expect(serialGC.serialPort.port.recording.toString()).to.equal(testPattern)
+    winston.info({message: name +': END serialGC_TX test'});
   })
 
   //

--- a/unit_tests/socketServer.spec.js
+++ b/unit_tests/socketServer.spec.js
@@ -30,7 +30,7 @@ config.currentUserDirectory = config.singleUserDirectory
 config.appStorageDirectory =  testAppStoragePath
 
 // set config items
-config.setSocketServerPort(5552);
+config.setSocketServerPort(0);
 
 
 const mock_messageRouter = require('./mock_messageRouter')(config)
@@ -46,25 +46,13 @@ const node = require('./../VLCB-server/mergAdminNode.js')(config)
 const programNode = require('../VLCB-server/programNodeMMC.js')(config)
 
 node.inUnitTest = true
-socketServer.socketServer(config, node, mock_messageRouter, cbusServer, programNode, status)
+let testSocketServer
 
 const name = 'unit_test: socketServer'
 
 describe('socketServer tests', async function(){
 
-
-  const socket = io(`http://${"localhost"}:${config.getSocketServerPort()}`)
-
-  // Add a connect listener
-  socket.on('connect', function () {
-    winston.info({message: 'socketserver: web socket Connected!'})
-  });
-
-  var layoutData = {}
-  socket.on('LAYOUT_DATA', function (data) {
-    layoutData = data;
-//    winston.debug({message: ' layoutData : ' + JSON.stringify(layoutData)});
-    });	
+  let socket
 
 	before(async function() {
 		winston.info({message: ' '});
@@ -74,7 +62,14 @@ describe('socketServer tests', async function(){
 		winston.info({message: '================================================================================'});
 		winston.info({message: ' '});
         
-    await utils.sleep(200)
+    testSocketServer = socketServer.socketServer(config, node, mock_messageRouter, cbusServer, programNode, status)
+    const address = await testSocketServer.listening
+    socket = io(`http://localhost:${address.port}`, {autoConnect: false})
+    await new Promise((resolve, reject) => {
+      socket.once('connect', resolve)
+      socket.once('connect_error', reject)
+      socket.connect()
+    })
     //
     // Use local 'user' directory for tests...
     config.singleUserConfigPath = "./unit_tests/test_output/test_user"
@@ -86,12 +81,15 @@ describe('socketServer tests', async function(){
         // ensure expected CAN header is reset before each test run
 	});
 
-	after(function(done) {
+	after(async function() {
 		winston.info({message: ' '});   // blank line to separate tests
-    // bit of timing to ensure all winston messages get sent before closing tests completely
-    setTimeout(function(){
-      done();
-    }, 100);
+    if (socket) {
+      socket.removeAllListeners()
+      socket.disconnect()
+    }
+    if (testSocketServer) {
+      await testSocketServer.close()
+    }
 	});																										
 
 
@@ -110,6 +108,26 @@ describe('socketServer tests', async function(){
       testCases.push({'nodeNumber':arg1});
     }
     return testCases;
+  }
+
+  function waitForSocketEvent(eventName, action) {
+    return new Promise((resolve) => {
+      socket.once(eventName, resolve)
+      action()
+    })
+  }
+
+  async function waitForSocketBarrier() {
+    await waitForSocketEvent('BUS_CONNECTION', () => socket.emit('REQUEST_BUS_CONNECTION'))
+  }
+
+  async function waitForCBUSMessages(expectedCount, timeoutMs = 2000) {
+    const timeout = Date.now() + timeoutMs
+    while ((node.CBUS_Queue.length > 0 || mock_messageRouter.messagesIn.length < expectedCount) && Date.now() < timeout) {
+      await utils.sleep(1)
+    }
+    expect(node.CBUS_Queue.length).to.equal(0)
+    expect(mock_messageRouter.messagesIn.length).to.equal(expectedCount)
   }
 
   function GetTestCase_event() {
@@ -131,7 +149,7 @@ describe('socketServer tests', async function(){
   }
 
 
-  itParam("ACCESSORY_LONG_OFF test ${JSON.stringify(value)}", GetTestCase_event(), function (done, value) {
+  itParam("ACCESSORY_LONG_OFF test ${JSON.stringify(value)}", GetTestCase_event(), async function (value) {
     winston.info({message: name +': BEGIN ACCESSORY_LONG_OFF test  ' + JSON.stringify(value)});
     mock_messageRouter.messagesIn = []
     if ((value.nodeNumber == undefined) && (value.eventNumber == undefined)){
@@ -143,26 +161,24 @@ describe('socketServer tests', async function(){
         "eventNumber": value.eventNumber
       })
     }
-    //
-    setTimeout(function(){
-      if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+    await waitForSocketBarrier()
+    if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+        await waitForCBUSMessages(1)
         winston.info({message: name + ': raw result ' + mock_messageRouter.messagesIn[0]});
         const CbusMsg = mock_messageRouter.messagesIn[0]
         winston.info({message: name + ': result ' + JSON.stringify(CbusMsg)});
         expect(CbusMsg.mnemonic).to.equal("ACOF");
         expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber);
         expect(CbusMsg.eventNumber).to.equal(value.eventNumber);
-      } else {
+    } else {
         // if either parameter is undefined, then no message should be generated
         expect(mock_messageRouter.messagesIn.length).to.equal(0);
-      }
-      winston.info({message: name + ': END ACCESSORY_LONG_OFF test'});
-			done();
-		}, 50);
+    }
+    winston.info({message: name + ': END ACCESSORY_LONG_OFF test'});
   })
 
 
-  itParam("ACCESSORY_LONG_ON test ${JSON.stringify(value)}", GetTestCase_event(), function (done, value) {
+  itParam("ACCESSORY_LONG_ON test ${JSON.stringify(value)}", GetTestCase_event(), async function (value) {
     winston.info({message: name + ': BEGIN ACCESSORY_LONG_ON test ' + JSON.stringify(value)});
     mock_messageRouter.messagesIn = []
     if ((value.nodeNumber == undefined) && (value.eventNumber == undefined)){
@@ -174,26 +190,24 @@ describe('socketServer tests', async function(){
         "eventNumber": value.eventNumber
       })
     }
-    //
-    setTimeout(function(){
-      if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+    await waitForSocketBarrier()
+    if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+        await waitForCBUSMessages(1)
         winston.info({message: name + ': raw result ' + mock_messageRouter.messagesIn[0]});
         const CbusMsg = mock_messageRouter.messagesIn[0]
         winston.info({message: name + ': result ' + JSON.stringify(CbusMsg)});
         expect(CbusMsg.mnemonic).to.equal("ACON");
         expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber);
         expect(CbusMsg.eventNumber).to.equal(value.eventNumber);
-      } else {
+    } else {
         // if either parameter is undefined, then no message should be generated
         expect(mock_messageRouter.messagesIn.length).to.equal(0);
-      }
-      winston.info({message: name +': END ACCESSORY_LONG_ON test'});
-			done();
-		}, 50);
+    }
+    winston.info({message: name +': END ACCESSORY_LONG_ON test'});
   })
 
 
-  itParam("ACCESSORY_SHORT_OFF test ${JSON.stringify(value)}", GetTestCase_event(), function (done, value) {
+  itParam("ACCESSORY_SHORT_OFF test ${JSON.stringify(value)}", GetTestCase_event(), async function (value) {
     winston.info({message: name +': BEGIN ACCESSORY_SHORT_OFF test  ' + JSON.stringify(value)});
     mock_messageRouter.messagesIn = []
     if ((value.nodeNumber == undefined) && (value.eventNumber == undefined)){
@@ -205,26 +219,24 @@ describe('socketServer tests', async function(){
         "deviceNumber": value.eventNumber
       })
     }
-    //
-    setTimeout(function(){
-      if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+    await waitForSocketBarrier()
+    if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+        await waitForCBUSMessages(1)
         winston.info({message: name + ': raw result ' + mock_messageRouter.messagesIn[0]});
         const CbusMsg = mock_messageRouter.messagesIn[0]
         winston.info({message: name + ': result ' + JSON.stringify(CbusMsg)});
         expect(CbusMsg.mnemonic).to.equal("ASOF");
         expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber);
         expect(CbusMsg.deviceNumber).to.equal(value.eventNumber);
-      } else {
+    } else {
         // if either parameter is undefined, then no message should be generated
         expect(mock_messageRouter.messagesIn.length).to.equal(0);
-      }
-      winston.info({message: name + ': END ACCESSORY_SHORT_OFF test'});
-			done();
-		}, 50);
+    }
+    winston.info({message: name + ': END ACCESSORY_SHORT_OFF test'});
   })
 
 
-  itParam("ACCESSORY_SHORT_ON test ${JSON.stringify(value)}", GetTestCase_event(), function (done, value) {
+  itParam("ACCESSORY_SHORT_ON test ${JSON.stringify(value)}", GetTestCase_event(), async function (value) {
     winston.info({message: name +': BEGIN ACCESSORY_SHORT_ON test  ' + JSON.stringify(value)});
     mock_messageRouter.messagesIn = []
     if ((value.nodeNumber == undefined) && (value.eventNumber == undefined)){
@@ -236,39 +248,30 @@ describe('socketServer tests', async function(){
         "deviceNumber": value.eventNumber
       })
     }
-    //
-    setTimeout(function(){
-      if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+    await waitForSocketBarrier()
+    if((value.nodeNumber != undefined) && (value.eventNumber != undefined)) {
+        await waitForCBUSMessages(1)
         winston.info({message: name + ': raw result ' + mock_messageRouter.messagesIn[0]});
         const CbusMsg = mock_messageRouter.messagesIn[0]
         winston.info({message: name + ': result ' + JSON.stringify(CbusMsg)});
         expect(CbusMsg.mnemonic).to.equal("ASON");
         expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber);
         expect(CbusMsg.deviceNumber).to.equal(value.eventNumber);
-      } else {
+    } else {
         // if either parameter is undefined, then no message should be generated
         expect(mock_messageRouter.messagesIn.length).to.equal(0);
-      }
-      winston.info({message: name + ': END ACCESSORY_SHORT_ON test'});
-			done();
-		}, 50);
+    }
+    winston.info({message: name + ': END ACCESSORY_SHORT_ON test'});
   })
 
   //
   //
-  it("request_layout_list test", function (done) {
+  it("request_layout_list test", async function () {
     winston.info({message: 'unit_test: BEGIN request_layout_list test '});
     //
-    socket.once('LAYOUTS_LIST', function (data) {
-			var layouts_list = data;
-			winston.info({message: ' LAYOUTS_LIST : ' + JSON.stringify(layouts_list)});
-			});	
-    socket.emit('REQUEST_LAYOUTS_LIST')
-    //
-    setTimeout(function(){
-      winston.info({message: 'unit_test: END request_layout_list test'});
-			done();
-		}, 100);
+    const layoutsList = await waitForSocketEvent('LAYOUTS_LIST', () => socket.emit('REQUEST_LAYOUTS_LIST'))
+    winston.info({message: ' LAYOUTS_LIST : ' + JSON.stringify(layoutsList)});
+    winston.info({message: 'unit_test: END request_layout_list test'});
   })
 
 
@@ -285,16 +288,14 @@ describe('socketServer tests', async function(){
 
 
   //
-  itParam("change_layout test ${JSON.stringify(value)}", GetTestCase_layout(), function (done, value) {
+  itParam("change_layout test ${JSON.stringify(value)}", GetTestCase_layout(), async function (value) {
     winston.info({message: 'unit_test: BEGIN change_layout test '});
-    socket.emit('CHANGE_LAYOUT', {"layoutName": value.layout})
-    //
-    setTimeout(function(){
-      winston.info({message: ' layoutData : ' + JSON.stringify(layoutData)});
-      expect(layoutData.layoutDetails.title).to.equal(value.layout.toUpperCase());
-      winston.info({message: 'unit_test: END change_layout test'});
-			done();
-		}, 100);
+    const layoutData = await waitForSocketEvent('LAYOUT_DATA', () => {
+      socket.emit('CHANGE_LAYOUT', {"layoutName": value.layout.toUpperCase()})
+    })
+    winston.info({message: ' layoutData : ' + JSON.stringify(layoutData)});
+    expect(layoutData.layoutDetails.title).to.equal(value.layout.toUpperCase());
+    winston.info({message: 'unit_test: END change_layout test'});
   })
 
   /*
@@ -314,23 +315,16 @@ describe('socketServer tests', async function(){
 */
 
   //
-  it("request_version test", function (done) {
+  it("request_version test", async function () {
     winston.info({message: 'unit_test: BEGIN request_version test '});
     //
-    socket.once('VERSION', function (data) {
-			var version = data;
-			winston.info({message: ' VERSION : ' + JSON.stringify(version)});
-			});	
-    socket.emit('REQUEST_VERSION')
-    //
-    setTimeout(function(){
-      winston.info({message: 'unit_test: END request_version test'});
-			done();
-		}, 100);
+    const version = await waitForSocketEvent('VERSION', () => socket.emit('REQUEST_VERSION'))
+    winston.info({message: ' VERSION : ' + JSON.stringify(version)});
+    winston.info({message: 'unit_test: END request_version test'});
   })
 
 
-  itParam("SET_CAN_ID test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (done, value) {
+  itParam("SET_CAN_ID test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN SET_CAN_ID test - nodeNumber ' + value.nodeNumber});
     mock_messageRouter.messagesIn = []
     var data = {
@@ -338,72 +332,54 @@ describe('socketServer tests', async function(){
       CAN_ID: 1
     }
     socket.emit('SET_CAN_ID', data)
-
-    setTimeout(function(){
-      const CbusMsg = mock_messageRouter.messagesIn[0]
-      winston.info({message: 'unit_test: result ' + JSON.stringify(CbusMsg)});
-      expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber)
-      expect(CbusMsg.CAN_ID).to.equal(1)
-      winston.info({message: 'unit_test: END SET_CAN_ID test'});
-			done();
-		}, 200);
+    await waitForSocketBarrier()
+    await waitForCBUSMessages(1)
+    const CbusMsg = mock_messageRouter.messagesIn[0]
+    winston.info({message: 'unit_test: result ' + JSON.stringify(CbusMsg)});
+    expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber)
+    expect(CbusMsg.CAN_ID).to.equal(1)
+    winston.info({message: 'unit_test: END SET_CAN_ID test'});
   })
 
 
-  itParam("SET_NODE_NUMBER test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (done, value) {
+  itParam("SET_NODE_NUMBER test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN SET_NODE_NUMBER test - nodeNumber ' + value.nodeNumber});
     mock_messageRouter.messagesIn = []
     socket.emit('SET_NODE_NUMBER', value.nodeNumber)
-
-    setTimeout(function(){
-      const CbusMsg = mock_messageRouter.messagesIn[0]
-      winston.info({message: 'unit_test: result ' + JSON.stringify(CbusMsg)});
-      expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber)
-      winston.info({message: 'unit_test: END SET_NODE_NUMBER test'});
-			done();
-		}, 200);
+    await waitForSocketBarrier()
+    await waitForCBUSMessages(1)
+    const CbusMsg = mock_messageRouter.messagesIn[0]
+    winston.info({message: 'unit_test: result ' + JSON.stringify(CbusMsg)});
+    expect(CbusMsg.nodeNumber).to.equal(value.nodeNumber)
+    winston.info({message: 'unit_test: END SET_NODE_NUMBER test'});
   })
 
 
   //
   //
-  itParam("REQUEST_NODE_NUMBER test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), function (done, value) {
+  itParam("REQUEST_NODE_NUMBER test ${JSON.stringify(value)}", GetTestCase_nodeNumber(), async function (value) {
     winston.info({message: 'unit_test: BEGIN REQUEST_NODE_NUMBER test '});
     var testMessage = cbusLib.encodeRQNN(value.nodeNumber)
     mock_messageRouter.messagesIn = []
     node.rqnnPreviousNodeNumber = value.nodeNumber
     //node.createNodeConfig(value.nodeNumber)    // create node config for node we're testing
-    var receivedNodeNumber = undefined
-    var receivedNAME = undefined
-    socket.once('REQUEST_NODE_NUMBER', function (nodeNumber, name) {
-      receivedNodeNumber = nodeNumber
-      receivedNAME = name
-      winston.debug({message: 'unit_test: node.once - REQUEST_NODE_NUMBER ' + nodeNumber});
+    const response = new Promise((resolve) => {
+      socket.once('REQUEST_NODE_NUMBER', function (nodeNumber, name) {
+        resolve({nodeNumber, name})
+      })
     })
     mock_messageRouter.inject(testMessage)
-    setTimeout(function(){
-      expect(receivedNodeNumber).to.equal(value.nodeNumber)
-      expect(receivedNAME).to.equal("")   // won't get a name for this test
-      winston.info({message: 'unit_test: END REQUEST_NODE_NUMBER test'});
-			done();
-		}, 300);
+    const received = await response
+    expect(received.nodeNumber).to.equal(value.nodeNumber)
+    expect(received.name).to.equal("")   // won't get a name for this test
+    winston.info({message: 'unit_test: END REQUEST_NODE_NUMBER test'});
   })
 
 
-  it("REQUEST_BUS_CONNECTION test", function (done) {
+  it("REQUEST_BUS_CONNECTION test", async function () {
     winston.info({message: name + ': BEGIN REQUEST_BUS_CONNECTION test '});
-    var result = false
-    socket.once('BUS_CONNECTION', function () {
-      result = true
-    })
-    socket.emit('REQUEST_BUS_CONNECTION')
-    //
-    setTimeout(function(){
-      winston.info({message: name + ': result ' + result});
-      expect (result).to.equal(true)
-      winston.info({message: name + ': END REQUEST_BUS_CONNECTION test'});
-			done();
-		}, 200);
+    await waitForSocketEvent('BUS_CONNECTION', () => socket.emit('REQUEST_BUS_CONNECTION'))
+    winston.info({message: name + ': END REQUEST_BUS_CONNECTION test'});
   })
 
 
@@ -434,7 +410,7 @@ describe('socketServer tests', async function(){
   }
 
 
-  itParam("EVENT_TEACH_BY_IDENTIFIER test ${JSON.stringify(value)}", GetTestCase_teach_event(), function (done, value) {
+  itParam("EVENT_TEACH_BY_IDENTIFIER test ${JSON.stringify(value)}", GetTestCase_teach_event(), async function (value) {
     winston.info({message: 'unit_test: BEGIN EVENT_TEACH_BY_IDENTIFIER test '});
     mock_messageRouter.messagesIn = []
     node.nodeConfig.nodes = {}          // start with clean slate
@@ -445,111 +421,70 @@ describe('socketServer tests', async function(){
     }
     node.updateEventInNodeConfig(value.nodeNumber, value.eventIdentifier, 1)
     socket.emit('EVENT_TEACH_BY_IDENTIFIER', data)
-
-    setTimeout(function(){
-      for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
-        winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
-      }
-      expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NNLRN")
-      expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("EVLRN")
-      expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("NNULN")
-      expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal("REVAL")
-      winston.info({message: 'unit_test: END EVENT_TEACH_BY_IDENTIFIER test'});
-			done();
-		}, 300);
+    await waitForSocketBarrier()
+    await waitForCBUSMessages(4)
+    for (let i = 0; i < mock_messageRouter.messagesIn.length; i++) {
+      winston.info({message: 'unit_test: messagesIn ' + JSON.stringify(mock_messageRouter.messagesIn[i])});
+    }
+    expect(mock_messageRouter.messagesIn[0].mnemonic).to.equal("NNLRN")
+    expect(mock_messageRouter.messagesIn[1].mnemonic).to.equal("EVLRN")
+    expect(mock_messageRouter.messagesIn[2].mnemonic).to.equal("NNULN")
+    expect(mock_messageRouter.messagesIn[3].mnemonic).to.equal("REVAL")
+    winston.info({message: 'unit_test: END EVENT_TEACH_BY_IDENTIFIER test'});
   })
 
   //
   //
-  it("SAVE_SETTING test", function (done) {
+  it("SAVE_SETTING test", async function () {
     winston.info({message: 'unit_test: BEGIN SAVE_SETTING test '});
     //
     socket.emit('SAVE_SETTING',{"lastUsedExportFolder":"xxxx"})
-    //
-    setTimeout(function(){
-      expect(config.appSettings.lastUsedExportFolder).to.equal("xxxx")
-      winston.info({message: 'unit_test: END SAVE_SETTING test'});
-			done();
-		}, 100);
+    await waitForSocketBarrier()
+    expect(config.appSettings.lastUsedExportFolder).to.equal("xxxx")
+    winston.info({message: 'unit_test: END SAVE_SETTING test'});
   })
 
   //
   //
-  it("REQUEST_FIRMWARE_INFO test", function (done) {
+  it("REQUEST_FIRMWARE_INFO test", async function () {
     winston.info({message: name + ': BEGIN REQUEST_FIRMWARE_INFO test '});
-    var result = false
-    let returnData = null
-    socket.once('FIRMWARE_INFO', function (data) {
-      returnData = data
-      winston.debug({message: name + `: FIRMWARE_INFO: data: ${JSON.stringify(data)}`});
-      result = true
-    })
     let filename = './unit_tests/test_firmware/CANACC5_v2v.hex'
     winston.info({message: 'UNIT_TEST: REQUEST_FIRMWARE_INFO test: Filename: ' + filename});
     var intelHexString = fs.readFileSync(filename);
     //    
-    socket.emit('REQUEST_FIRMWARE_INFO', intelHexString)
-    //
-    setTimeout(function(){
-      winston.info({message: name + ': result ' + result});
-      winston.info({message: name + `: data ${JSON.stringify(returnData)}`});
-      expect (result).to.equal(true)
-      expect (returnData.valid).to.equal(true)
-      expect (returnData.moduleID).to.equal(2)
-      expect (returnData.targetCpuType).to.equal(1)
-      winston.info({message: name + ': END REQUEST_FIRMWARE_INFO test'});
-			done();
-		}, 100);
+    const returnData = await waitForSocketEvent('FIRMWARE_INFO', () => {
+      socket.emit('REQUEST_FIRMWARE_INFO', intelHexString)
+    })
+    winston.info({message: name + `: data ${JSON.stringify(returnData)}`});
+    expect (returnData.valid).to.equal(true)
+    expect (returnData.moduleID).to.equal(2)
+    expect (returnData.targetCpuType).to.equal(1)
+    winston.info({message: name + ': END REQUEST_FIRMWARE_INFO test'});
   })
 
 
 
   //
   //
-  it("REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES test", function (done) {
+  it("REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES test", async function () {
     winston.info({message: name + ': BEGIN REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES test '});
-    var result = false
-    let returnData = null
-    socket.once('LIST_OF_BACKUPS_FOR_ALL_NODES', function (data) {
-      returnData = data
-      winston.debug({message: name + `: LIST_OF_BACKUPS_FOR_ALL_NODES: data: ${JSON.stringify(data)}`});
-      result = true
+    const returnData = await waitForSocketEvent('LIST_OF_BACKUPS_FOR_ALL_NODES', () => {
+      socket.emit('REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES', {"layoutName":'test_backup_layout'})
     })
-    //    
-    socket.emit( 'REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES', {"layoutName":'test_backup_layout'} )
-    //
-    setTimeout(function(){
-      winston.info({message: name + ': result ' + result});
-      winston.info({message: name + `: data ${JSON.stringify(returnData)}`});
-      expect (result).to.equal(true)
-      winston.info({message: name + ': END REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES test'});
-			done();
-		}, 100);
+    winston.info({message: name + `: data ${JSON.stringify(returnData)}`});
+    winston.info({message: name + ': END REQUEST_LIST_OF_BACKUPS_FOR_ALL_NODES test'});
   })
 
 
   //
   //
-  it("REQUEST_LOG_FILE test", function (done) {
+  it("REQUEST_LOG_FILE test", async function () {
     winston.info({message: name + ': BEGIN REQUEST_LOG_FILE test '});
-    var result = false
-    var text = null
-    socket.once('LOG_FILE', function (data) {
-      winston.debug({message: name + `: LOG_FILE: data: ${JSON.stringify(data)}`});
-      text = atob(data.logFile)
-      result = true
-    })
     let targetData = {fileName:"bustraffic.txt"}
-    socket.emit('REQUEST_LOG_FILE', targetData)
-    //
-    setTimeout(function(){
-      winston.info({message: name + ': result ' + result});
-      //winston.info({message: name + ': text ' + text});
-      expect (result).to.equal(true)
-      expect (text.length).to.be.above(0)
-      winston.info({message: name + ': END REQUEST_LOG_FILE test'});
-			done();
-		}, 500);
+    const data = await waitForSocketEvent('LOG_FILE', () => socket.emit('REQUEST_LOG_FILE', targetData))
+    const text = atob(data.logFile)
+    expect (text.length).to.be.above(0)
+    winston.info({message: name + ': END REQUEST_LOG_FILE test'});
   })
 
 
@@ -557,5 +492,3 @@ describe('socketServer tests', async function(){
 
 
 })
-
-

--- a/unit_tests/socketServer.spec.js
+++ b/unit_tests/socketServer.spec.js
@@ -90,6 +90,8 @@ describe('socketServer tests', async function(){
     if (testSocketServer) {
       await testSocketServer.close()
     }
+    await cbusServer.close()
+    node.dispose()
 	});																										
 
 


### PR DESCRIPTION
Closes david284/MMC-SERVER#208.

  This adds automated coverage reporting for the server-side unit-test suite.

  ### Changes

  - Add c8 as a development dependency.
  - Add an npm run test:coverage command.
  - Include main.js and all JavaScript files under VLCB-server, including files not loaded by the tests.
  - Produce human-readable terminal output and an LCOV report.
  - Run the coverage command in CI.
  - Upload coverage/lcov.info as a CI artifact.
  - Exclude generated coverage output from Git.

  No coverage thresholds are enforced yet. This establishes a baseline that can be improved by the follow-up coverage issues #209–#212.

  package-lock.json is intentionally not included because the upstream lockfile work tracked by #184 has not yet been merged.

  ## Validation

  - npm run test:coverage — 1038 tests passed
  - npm run lint — passed
  - GitHub Actions — passed
  - Coverage artifact uploaded successfully

  Current baseline:

  - Lines/statements: approximately 76%
  - Branches: approximately 68%
  - Functions: approximately 78%